### PR TITLE
adopt hunter.develop changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,98 @@
+---
+Language:        Cpp
+# BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+BreakBeforeInheritanceComma: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "3rdparty/aglet"]
-	path = 3rdparty/aglet
-	url = https://github.com/elucideye/aglet.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rdparty/aglet"]
+	path = 3rdparty/aglet
+	url = https://github.com/elucideye/aglet.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
 
     - os: osx
       osx_image: xcode8.1      
-      env: CONFIG=Release TOOLCHAIN=ios-10-1-arm64 INSTALL=--install MESA=OFF TEST=--test
+      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-10-1-arm64 INSTALL=--install MESA=OFF TEST=--test
 
     - os: osx
       osx_image: xcode8.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,26 +45,21 @@ matrix:
     - os: linux
       env: CONFIG=Release TOOLCHAIN=gcc INSTALL=--strip MESA=ON TEST=--test
 
-# OSError: [Errno 28] No space left on device
-# Travis ubuntu machines can't handle Android SDK installation?
-
-#    - os: linux
-#      env: CONFIG=Release TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon-hid-sections INSTALL=--strip MESA=OFF
-
     # }
 
     # OSX {
 
-    - os: osx
-      osx_image: xcode8.1      
-      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-10-1-arm64 INSTALL=--install MESA=OFF TEST=--test
+    # Try to match toolchains from ingenue deep tests to improve cache hits:
+    # https://github.com/ingenue/hunter/blob/pkg.opencv/.travis.yml
 
     - os: osx
-      osx_image: xcode8.1
-      env: CONFIG=Release TOOLCHAIN=osx-10-12-sanitize-address-hid-sections INSTALL=--install MESA=OFF TEST=--test
+      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-9-3-arm64 INSTALL=--install MESA=OFF TEST=--test
+
+    - os: osx
+      env: CONFIG=Release TOOLCHAIN=osx-10-11 INSTALL=--install MESA=OFF TEST=--test
       
     - os: osx
-      env: CONFIG=Release TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon-hid-sections INSTALL=--strip MESA=OFF TEST=--test
+      env: CONFIG=Release TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon INSTALL=--strip MESA=OFF TEST=--test
 
     # }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # OSX/Linux (https://github.com/travis-ci-tester/toolchain-table)
 
+# Original: https://github.com/forexample/hunter-simple/blob/master/.travis.yml
+
 language:
   - cpp
 
@@ -8,63 +10,67 @@ language:
 sudo:
   - false
 
+dist:
+  - trusty
+
 # Install packages differs for container-based infrastructure
 # * https://docs.travis-ci.com/user/migrating-from-legacy/#How-do-I-install-APT-sources-and-packages%3F
-# * http://stackoverflow.com/a/30925448/2288008
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
+      - ubuntu-toolchain-r-test    
     packages:
-      - python3
+      # For off screen rendering 
+      - libegl1-mesa-dev
+      - libosmesa6-dev
 
-      # python3-pip package is not available, use 'easy_install3':
-      # * https://github.com/travis-ci/apt-package-whitelist/issues/768
-      - python3-setuptools # easy_install3
+      # xorg-macros: https://github.com/BlueDragonX/xf86-input-mtrack/issues/27#issuecomment-186871891
+      - xutils-dev
+      - xserver-xorg-dev-lts-trusty      
 
-      # https://github.com/travis-ci-tester/travis-test-clang-cxx-11
-      - libstdc++-4.8-dev
+      # Packages for Android development: http://superuser.com/a/360398/252568
+      - libncurses5:i386
+      - libstdc++6:i386
+      - zlib1g:i386
 
-      # https://github.com/travis-ci-tester/travis-test-gcc-cxx-11
-      - g++-4.8
-  
+      # Default GCC 4.8 is buggy:
+      # * https://github.com/elucideye/drishti/issues/273#issuecomment-301297286
+      #- g++-5
+      #- gcc-5      
+      
 matrix:
   include:
     # Linux {
+
     - os: linux
-      env: CONFIG=Release TOOLCHAIN=gcc-4-8-pic-hid-sections INSTALL=--strip
-    # - os: linux
-    #   env: CONFIG=Debug TOOLCHAIN=gcc-4-8-pic-hid-sections INSTALL=--strip
-    - os: linux
-      env: CONFIG=Release TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon-hid-sections INSTALL=--strip
-    # - os: linux
-    #   env: CONFIG=Debug TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon-hid-sections INSTALL=--strip
+      env: CONFIG=Release TOOLCHAIN=gcc INSTALL=--strip MESA=ON TEST=--test
+
+# OSError: [Errno 28] No space left on device
+# Travis ubuntu machines can't handle Android SDK installation?
+
+#    - os: linux
+#      env: CONFIG=Release TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon-hid-sections INSTALL=--strip MESA=OFF
+
     # }
 
     # OSX {
-    # - os: osx
-    #   env: CONFIG=Release TOOLCHAIN=libcxx-hid-sections INSTALL=--strip
-    # - os: osx
-    #  env: CONFIG=Debug TOOLCHAIN=libcxx-hid-sections INSTALL=--strip
+
     - os: osx
-      env: CONFIG=Release TOOLCHAIN=osx-10-11-hid-sections INSTALL=--install
-    # - os: osx
-    #   env: CONFIG=Debug TOOLCHAIN=osx-10-11-hid-sections INSTALL=--install
-    - os: osx
-      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-9-3-device-hid-sections INSTALL=--install
-    # - os: osx
-    #   env: CONFIG=Debug TOOLCHAIN=ios-nocodesign-9-3-device-hid-sections INSTALL=--install
+      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-9-3-device-hid-sections INSTALL=--install MESA=OFF TEST=--test
+
     - os: osx
       osx_image: xcode8.1
-      env: CONFIG=Release TOOLCHAIN=osx-10-12-sanitize-address-hid-sections INSTALL=--install
+      env: CONFIG=Release TOOLCHAIN=osx-10-12-sanitize-address-hid-sections INSTALL=--install MESA=OFF TEST=--test
+      
     - os: osx
-      osx_image: xcode8.1
-      env: CONFIG=Debug TOOLCHAIN=osx-10-12-sanitize-address-hid-sections INSTALL=--install
-    - os: osx
-      env: CONFIG=Release TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon-hid-sections INSTALL=--strip
-    # - os: osx
-    #   env: CONFIG=Debug TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon-hid-sections INSTALL=--strip
-    # }      
+      env: CONFIG=Release TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon-hid-sections INSTALL=--strip MESA=OFF TEST=--test
+
+    # }
+
+before_install:
+
+  # Add '--quiet' to avoid leaking the token to logs
+  - git submodule update --init --recursive --quiet    
   
 install:
   # Info about OS
@@ -76,7 +82,7 @@ install:
   # Install Python package 'requests'
   # 'easy_install3' is not installed by 'brew install python3' on OS X 10.9 Maverick
   - if [[ "`uname`" == "Darwin" ]]; then pip3 install requests; fi
-  - if [[ "`uname`" == "Linux" ]]; then travis_retry easy_install3 --user requests==2.10.0; fi  
+  - if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user requests; fi  
 
   # Install latest Polly toolchains and scripts
   - wget https://github.com/ruslo/polly/archive/master.zip
@@ -93,18 +99,32 @@ install:
   # Installed if toolchain is Android (otherwise directory doesn't exist)
   - export ANDROID_NDK_r10e="`pwd`/_ci/android-ndk-r10e"
 
+  # Teach hunter-packages about system OSMesa: FindOSMesa.cmake
+  - CMAKE_MODULE_PATH=$(dirname $(find "${PWD}/_ci/cmake" -name "FindOpenGL.cmake"))
+  - FIND_OSMESA_CMAKE="${CMAKE_MODULE_PATH}/FindOSMesa.cmake"
+  - echo "find_package (PkgConfig)" > "${FIND_OSMESA_CMAKE}"
+  - echo "pkg_check_modules (PKG_OSMESA QUIET osmesa)" >> "${FIND_OSMESA_CMAKE}"
+  - echo "set (OSMESA_INCLUDE_DIR \${PKG_OSMESA_INCLUDE_DIRS})" >> "${FIND_OSMESA_CMAKE}"
+  - echo "set (OSMESA_LIBRARIES   \${PKG_OSMESA_LIBRARIES})" >> "${FIND_OSMESA_CMAKE}"
+    
 script:
-  
+
   - >
     polly.py
     --toolchain ${TOOLCHAIN}
     --config ${CONFIG}
     --verbose
+    --ios-multiarch --ios-combined
     --fwd HUNTER_CONFIGURATION_TYPES=${CONFIG}
     OGLES_GPGPU_BUILD_TESTS=ON
-    --test
-    --discard 10
+    OGLES_GPGPU_USE_OSMESA=${MESA}
+    GAUZE_ANDROID_USE_EMULATOR=YES
+    HUNTER_CONFIGURATION_TYPES=${CONFIG}
+    HUNTER_SUPPRESS_LIST_OF_FILES=ON
+    --discard 4
     --tail 100
+    --jobs 2
+    ${INSTALL} ${TEST}
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,8 @@ matrix:
     # OSX {
 
     - os: osx
-      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-9-3-device-hid-sections INSTALL=--install MESA=OFF TEST=--test
+      osx_image: xcode8.1      
+      env: CONFIG=Release TOOLCHAIN=ios-10-1-arm64 INSTALL=--install MESA=OFF TEST=--test
 
     - os: osx
       osx_image: xcode8.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,10 @@ matrix:
     # https://github.com/ingenue/hunter/blob/pkg.opencv/.travis.yml
 
     - os: osx
-      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-9-3-arm64 INSTALL=--install MESA=OFF TEST=--test
+      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-9-3-arm64 INSTALL=--install MESA=OFF
 
     - os: osx
-      env: CONFIG=Release TOOLCHAIN=osx-10-11 INSTALL=--install MESA=OFF TEST=--test
+      env: CONFIG=Release TOOLCHAIN=osx-10-11 INSTALL=--install MESA=OFF
       
     - os: osx
       env: CONFIG=Release TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon INSTALL=--strip MESA=OFF TEST=--test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,13 @@ if(OGLES_GPGPU_BUILD_TESTS)
   find_package(GTest CONFIG REQUIRED)
   list(APPEND OGLES_GPGPU_TEST_LIBS GTest::gtest)  
 
-  # Use aglet for portable lightweight off screen opengl context
+  if(MSVC)
+    # TODO: Temporary aglet fix for appveyor?  Shouldn't be needed.
+    hunter_add_package(glew)
+    find_package(glew CONFIG REQUIRED)
+  endif()
+
+  # Use aglet for portable lightweight off screen opengl context  
   hunter_add_package(aglet)
   find_package(aglet CONFIG REQUIRED)
   list(APPEND OGLES_GPGPU_TEST_LIBS aglet::aglet)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-  URL "https://github.com/ruslo/hunter/archive/v0.18.29.tar.gz"
-  SHA1 "ebea5d2fa4aa70de1234b05c4bf1b69705abb1ba"
+  URL "https://github.com/ruslo/hunter/archive/v0.19.26.tar.gz"
+  SHA1 "362b3c2fd8f0f50fc03cec5105be8fd4376ea886"  
   LOCAL
   )
 
@@ -16,12 +16,18 @@ project(ogles_gpgpu VERSION 0.2.0)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+string(COMPARE EQUAL "${CMAKE_SYSTEM_NAME}" "Linux" is_linux)
+
+option(OGLES_GPGPU_BUILD_EXAMPLES "Build examples" OFF)
+option(OGLES_GPGPU_INSTALL "Perform installation" ON)
+option(OGLES_GPGPU_VERBOSE "Perform per filter logging" OFF)
+option(OGLES_GPGPU_BUILD_TESTS "Build shader unit tests" OFF)
+option(OGLES_GPGPU_USE_OSMESA "Use MESA CPU OpenGL (via glfw)" OFF)
+
 # See: cmake/Hunter/config.cmake
 hunter_add_package(Sugar)
 include("${SUGAR_ROOT}/cmake/Sugar")
 include(sugar_include)
-
-string(COMPARE EQUAL "${CMAKE_SYSTEM_NAME}" "Linux" is_linux)
 
 message("Android: ${ANDROID}")
 message("iOS    : ${IOS}")
@@ -32,73 +38,53 @@ if(XCODE)
   set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Configuration types")
 endif()
 
-option(OGLES_GPGPU_BUILD_EXAMPLES "Build examples" OFF)
-option(OGLES_GPGPU_INSTALL "Perform installation" ON)
-option(OGLES_GPGPU_VERBOSE "Perform per filter logging" OFF)
-
 ## #################################################################
 ## Testing: 
 ## #################################################################
+
+string(COMPARE EQUAL "$ENV{TRAVIS}" "true" travis_ci)
+string(COMPARE EQUAL "$ENV{APPVEYOR}" "True" appveyor_ci)
+if(travis_ci OR appveyor_ci)
+  set(OGLES_GPGPU_CI TRUE)
+else()
+  set(OGLES_GPGPU_CI FALSE)
+endif()
+
+if(ANDROID OR NOT ${OGLES_GPGPU_CI})
+  set(OGLES_GPGPU_DO_GPU_TESTING TRUE)
+else()
+  set(OGLES_GPGPU_DO_GPU_TESTING FALSE)
+endif()
 
 # Tests can be compiled for all platforms (to tests exe linking),
 # but they may only be run on platforms where an OpenGL context
 # is available
-  
-option(OGLES_GPGPU_BUILD_TESTS "Build shader unit tests" OFF)
 if(OGLES_GPGPU_BUILD_TESTS)
 
-  enable_testing()    
-
-  hunter_add_package(GTest)
-  find_package(GTest CONFIG REQUIRED)
-  list(APPEND OGLES_GPGPU_TEST_LIBS GTest::gtest)
-
-  # Include glfw for lightweight hidden window opengl context:
-  # Alternatives: boost or glm for iOS and Android
-  if(NOT (IOS OR ANDROID))
-    hunter_add_package(glfw)
-    find_package(glfw3 REQUIRED)
-    list(APPEND OGLES_GPGPU_TEST_LIBS glfw)
-    set(ogles_gpgpug_has_glfw TRUE)
+  if(IOS AND DRISHTI_CI)
+    # do not run test on CI (TODO: remote device testing)
+  else()
+    enable_testing()
   endif()
 
-  if(MSVC)
-    hunter_add_package(glew)
-    find_package(glew CONFIG REQUIRED)
-    list(APPEND OGLES_GPGPU_TEST_LIBS glew::glew)
-  endif()  
-  
+  # Use GTest as unit test framework
+  hunter_add_package(GTest)
+  find_package(GTest CONFIG REQUIRED)
+  list(APPEND OGLES_GPGPU_TEST_LIBS GTest::gtest)  
+
+  # Use aglet for portable lightweight off screen opengl context
+  hunter_add_package(aglet)
+  find_package(aglet CONFIG REQUIRED)
+  list(APPEND OGLES_GPGPU_TEST_LIBS aglet::aglet)
+
+  # Use gauze for cross platform ctesting
+  hunter_add_package(gauze)
+  find_package(gauze CONFIG REQUIRED)
+  list(APPEND OGLES_GPGPU_TEST_LIBS gauze::gauze)
+
   hunter_add_package(OpenCV)
   find_package(OpenCV REQUIRED)
   list(APPEND OGLES_GPGPU_TEST_LIBS "${OpenCV_LIBS}")
-endif()
-
-## #################################################################
-## Testing: 
-## #################################################################
-
-if(NOT (IOS OR ANDROID OR MSVC))
-  
-  option(OGLES_GPGPU_BUILD_TESTS "Build shader unit tests" OFF)  
-  if(OGLES_GPGPU_BUILD_TESTS)
-
-    enable_testing()    
-
-    hunter_add_package(GTest)
-    find_package(GTest CONFIG REQUIRED)
-    list(APPEND OGLES_GPGPU_TEST_LIBS GTest::gtest)
-
-    # Include glfw for lightweight hidden window opengl context:
-    # Alternatives: boost or glm for iOS and Android
-    hunter_add_package(glfw)
-    find_package(glfw3 REQUIRED)
-    list(APPEND OGLES_GPGPU_TEST_LIBS glfw)
-    
-    hunter_add_package(OpenCV)
-    find_package(OpenCV REQUIRED)
-    list(APPEND OGLES_GPGPU_TEST_LIBS "${OpenCV_LIBS}")
-    
-  endif()
 endif()
 
 ## #################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-  URL "https://github.com/ruslo/hunter/archive/v0.19.26.tar.gz"
-  SHA1 "362b3c2fd8f0f50fc03cec5105be8fd4376ea886"  
+  URL "https://github.com/ruslo/hunter/archive/v0.19.29.tar.gz"
+  SHA1 "b0a69cd79597493f5e1e32d4cb77ff764807618a"  
   LOCAL
   )
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 | [![Build Status][travis_status]][travis_builds] | [![Build Status][appveyor_status]][appveyor_builds] |
 
 
-[travis_status]: https://travis-ci.org/headupinclouds/ogles_gpgpu.svg?branch=hunter
-[travis_builds]: https://travis-ci.org/headupinclouds/ogles_gpgpu
+[travis_status]: https://travis-ci.org/hunter-packages/ogles_gpgpu.svg?branch=master
+[travis_builds]: https://travis-ci.org/hunter-packages/ogles_gpgpu
 
 [appveyor_status]: https://ci.appveyor.com/api/projects/status/kv8cix0rf288ddcj?svg=true
 [appveyor_builds]: https://ci.appveyor.com/api/projects/headupinclouds/ogles_gpgpu
 
-UPDATE: In addition to the original build notes below, CMake support has been added via the [Hunter](https://github.com/ruslo/hunter) package manager with cross platform toolchains provided by [Polly](https://github.com/ruslo/polly).  See the README pages of these links for details.
+UPDATE: CMake support has been added via the [Hunter](https://github.com/ruslo/hunter) package manager with cross platform toolchains provided by [Polly](https://github.com/ruslo/polly).  See the README pages of these links for details.
 
 ## Features
 
@@ -20,113 +20,8 @@ UPDATE: In addition to the original build notes below, CMake support has been ad
  * on iOS: [Core Video Texture Cache API](http://allmybrain.com/2011/12/08/rendering-to-a-texture-with-ios-5-texture-cache-api/)
  * on Android: EGL pixelbuffers and [KHRImage extensions](http://snorp.net/2011/12/16/android-direct-texture.html)
 * well documented
-* contains several example applications
-* ~~LGPL~~ [Apache 2 licensed](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-See the [project page on my personal website](http://www.mkonrad.net/projects/ogles_gpgpu.html) for some more information and possible use-cases for this library.
-
-## Tested platforms
-
-* iOS 7.1 to 8.2
-* Android 4.2 to 5.0
-
-## Tested devices
-
-* Apple iPad 2
-* Apple iPad 4
-* Apple iPad Mini 2
-* Apple iPhone 4
-* Apple iPhone 4s
-* XCode Simulator
-* Google Nexus 10 (2013)
-
-## Example projects
-
-### iOS examples
-
-These examples should run out-of-the-box using XCode:
-
-* OGLESGPGPUStillImage - *Simple project that performs GPU-powered adaptive thresholding on different images*
-* OGLESGPGPUVideoCam - *Project that shows real-time GPU-powered image processing on video camera frames*
-
-### Android examples
-
-These projects were created with the Eclipse ADT and use the Android NDK. Instead of Eclipse, you can also use *Apache Ant* to compile the projects (see below). The following example projects are available:
-
-* OGStillImageDroid - *Simple project that performs GPU-powered adaptive thresholding on different images*
-* OGVideoProcDroid - *GPGPU based image processing of live camera frames*
-
-#### Prerequisites
-
-To compile, you need to install the [Android NDK](https://developer.android.com/tools/sdk/ndk/index.html) first.
-
-#### Compiling and running the projects using Eclipse
-
-You should [install the Eclipse C/C++ Development Tools (CDT)](http://mhandroid.wordpress.com/2011/01/23/using-eclipse-for-android-cc-development/). Then, do the following: Right click on the project in Eclipse, select *Properties > C/C++ Build > Environment*. Edit the variable *NDK_PATH* to point to your NDK root directory. You can now compile and run the project via Eclipse.
-
-#### Compiling and running the projects using Apache Ant
-
-1. go to the example project directory 
-2. run `android list targets` to find out the Android target ID
-3. run `android update project --target <TARGET_ID> --path . --name "<PROJECT_NAME>"`
-4. run `ndk-build && ant debug` to compile the native sources and create the project's APK file
-5. run `adb -d install bin/<PROJECT_NAME>-debug.apk` to install the APK file on your Android device
-
-You can now run the example application!
-
-## How to integrate *ogles_gpgpu* into your project
-
-### iOS
-
-You have two options to integrate the library into your project:
-
-#### Use the *ogles_gpgpu* static library XCode project
-
-1. Simply drag & drop the *ogles_gpgpu.xcodeproj* from the `xcode` folder into your project
-2. In your project, go to the *Build Phases* tab of your target. Under *Link Binary With Libraries* add *libogles_gpgpu.a*
-3. Include the header file `ogles_gpgpu/ogles_gpgpu.h` into your project's sources
-
-#### Use the *ogles_gpgpu* sources directly in your XCode project
-
-1. Simply drag & drop the *ogles_gpgpu* library sources to your project
-2. Delete references to Android specific sources so that they won't be compiled (under `platform/android`)
-3. Include the header file `ogles_gpgpu/ogles_gpgpu.h` into your project's sources
-
-### Android
-
-0. You need to install and set up the [Android NDK](https://developer.android.com/tools/sdk/ndk/index.html) first. It is also recommended to [install the Eclipse C/C++ Development Tools (CDT)](http://mhandroid.wordpress.com/2011/01/23/using-eclipse-for-android-cc-development/).
-1. In your Android project directory, create a folder `jni`. Then copy or link the files `og_jni_wrapper.h` and `og_jni_wrapper.cpp` from *ogles_gpgpu*'s `jni_wrapper` folder to the `jni` folder of your Android project.
-2. Copy `jni_wrapper/og_pipeline.template.h` and `jni_wrapper/og_pipeline.template.cpp` to your `jni` folder and rename them to `og_pipeline.h` and `og_pipeline.cpp`, respectively. This where you can later define the image processing pipeline. For now, leave it as it is.
-3. Copy `jni_wrapper/Android.template.mk` and `jni_wrapper/Application.template.mk` to your `jni` folder and rename them to `Android.mk` and `Application.mk`, respectively. Edit `Android.mk` and set the proper path to the *ogles_gpgpu* source in the variable `OG_SRC_PATH`.
-4. Try compiling the native sources by executing `ndk-build` in your Android project base directory. This should already succeed and the created `libog_jni_wrapper.so` library files will be copied to `libs/`.
-5. In your Android project directory, create a folder `src/ogles_gpgpu`. This is where the `OGJNIWrapper` Java source will reside. So link or copy `jni_wrapper/ogles_gpgpu/OGJNIWrapper.java` to `src/ogles_gpgpu`.
-6. In Eclipse, refresh your project sources (by pressing F5).
-7. In your project's Java source, you can now import `ogles_gpgpu.OGJNIWrapper` and use this class to set up an run *ogles_gpgpu*. See the Android examples on how to do that.
-
-You are ready to go now, basically. However, each time you change something on the C/C++ side of your code (which means everything in the `jni` folder), you will need to call `ndk-build` manually from the command line. The following describes how to set up Eclipse for C/C++ development, which makes the C/C++ workflow a lot easier. However, you need to install the Eclipse CDT first.
-
-1. In Eclipse, select *File > New > Other* and then select *Convert to C/C++ project* (don't be afraid, you will still be able to develop in Java, too!). Press *Next* and select *C++ project*. Under project options set *Makefile Project > Toolchains: Other Toolchain*. Do **not** use *Android GCC* here!
-2. Open your project *Properties*. Under *Properties > C/C++ Build > Environment*, add the variable *NDK_PATH* and set it to point to your NDK root directory.
-3. Still in your project *Properties*, under *Properties > C/C++ Build* in the *Builder Settings* tab, uncheck *Use default build command*. Instead, set the *Build command* to `${NDK_PATH}/ndk-build`. In the *Behaviour* tab delete the `all` value in the *Build (Incremental build)* field. This field needs to be empty.
-4. Yet still in your project *Properties*, under *Properties > C/C++ General > Paths and Symbols*, press *Add...* in the *Includes* tab. Set the *directory* value to `${NDK_PATH}/platforms/android-21/arch-arm/usr/include`. Now CDT knows where to look for Android-NDK-specific header files. Press *Add...* again and set the directory to the path where your *ogles_gpgpu* source resides. In the *Symbols* tab add two symbols: `ANDROID` and `__ANDROID__` (only the names, no value).
-5. Yet still in your project *Properties*, under *Properties > C/C++ General > Preprocessor Include Paths, etc.* go to the *Providers* tab and select *CDT GCC Built-In Compiler Settings*. After that, press *OK* and make sure the code analyzer's index will be rebuilt.
-
-Now you are better suited for C++ development on Android. When you start the *Run* command in Eclipse, the C++ sources will be automatically compiled via `ndk-build`. Check the *Console* output for details. Furthermore, the CDT code analyzer *(CODAN)* helps editing C++ code with auto-suggestions, warnings, errors, etc. However, sometimes CODAN fails properly analyzing the code and will display errors, although `ndk-build` succeeds. You will have to manually delete the errors in the *Problems* tab then.
-
-## Known Issues
-
-1. When using platform optimizations on Android (which enables using the ImageKHR extension), the first processing run will not produce any output (the buffer will only contain zeros). However, any successive runs will work normally.
-2. The "OGStillImageDroid" example application crashes when switching the screen off and on again. This is because `ogWrapper.init()` will try to initialize EGL again in `onResume()`, but this only works when the application was send to background and resumed again
-
-## TODO
-
-* test ipad3
-* rasp pi port
-* make some comparisons with CPU based image processing (OpenCV as reference)
-* AR support (include into ocv_ar)
-* more dynamic filters (-> shader code generator)
-* create own multipass filter (multiple gauss filters?)
-* native iOS YUV input support
+* contains several example applications (deprecated)
+* License: [Apache 2](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [travis_status]: https://travis-ci.org/hunter-packages/ogles_gpgpu.svg?branch=master
 [travis_builds]: https://travis-ci.org/hunter-packages/ogles_gpgpu
 
-[appveyor_status]: https://ci.appveyor.com/api/projects/status/kv8cix0rf288ddcj?svg=true
-[appveyor_builds]: https://ci.appveyor.com/api/projects/headupinclouds/ogles_gpgpu
+[appveyor_status]: https://ci.appveyor.com/api/projects/status/nuo2m8o09q562ogq/branch/hunter?svg=true
+[appveyor_builds]: https://ci.appveyor.com/project/headupinclouds/ogles-gpgpu-leruf/branch/hunter
 
 UPDATE: CMake support has been added via the [Hunter](https://github.com/ruslo/hunter) package manager with cross platform toolchains provided by [Polly](https://github.com/ruslo/polly).  See the README pages of these links for details.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,9 @@ install:
   - cmd: set PATH=%cd%\_ci\cmake\bin;%PATH%
   - cmd: set PATH=%cd%\_ci\ninja;%PATH%
 
+  # Add '--quiet' to avoid leaking the token to logs
+  - cmd: git submodule update --init --recursive --quiet    
+
   # Remove entry with sh.exe from PATH to fix error with MinGW toolchain
   # (For MinGW make to work correctly sh.exe must NOT be in your path)
   # * http://stackoverflow.com/a/3870338/2288008

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,8 +50,8 @@ install:
   - cmd: set MSYS_PATH=C:\msys64\usr\bin    
 
 build_script:
-  - cmd: python %POLLY_SOURCE_DIR%\bin\polly.py --toolchain "%TOOLCHAIN%" --config "%CONFIG%" --verbose --test --fwd OGLES_GPGPU_BUILD_TESTS=ON
-  
+  - cmd: python %POLLY_SOURCE_DIR%\bin\polly.py --toolchain "%TOOLCHAIN%" --config "%CONFIG%" --verbose --fwd OGLES_GPGPU_BUILD_TESTS=ON
+
 branches:
   except:
     - /^pr\..*/

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -4,6 +4,13 @@ include(CMakeFindDependencyMacro)
 
 if(@MSVC@)
   find_dependency(glew CONFIG)
+  find_dependency(OpenGL)
+elseif(@ANDROID@)
+  # Use system dependencies
+elseif(@APPLE@)
+  # IOS and OSX are using frameworks
+else()
+  find_dependency(OpenGL)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,9 +1,48 @@
 set(OPENCV_CMAKE_ARGS
 
+  BUILD_opencv_imgcodecs=ON  
+  BUILD_opencv_imgproc=ON
+  BUILD_opencv_video=ON
+  BUILD_opencv_videoio=ON
+  BUILD_opencv_highgui=ON  
+  
+  BUILD_opencv_calib3d=OFF
+  BUILD_opencv_contrib=OFF
+  BUILD_opencv_cudaarithm=OFF
+  BUILD_opencv_cudabgsegm=OFF
+  BUILD_opencv_cudacodec=OFF
+  BUILD_opencv_cudafeatures2d=OFF
+  BUILD_opencv_cudafilters=OFF
+  BUILD_opencv_cudaimgproc=OFF
+  BUILD_opencv_cudalegacy=OFF
+  BUILD_opencv_cudaobjdetect=OFF
+  BUILD_opencv_cudaoptflow=OFF
+  BUILD_opencv_cudastereo=OFF
+  BUILD_opencv_cudawarping=OFF
+  BUILD_opencv_cudev=OFF
+  BUILD_opencv_features2d=OFF
+  BUILD_opencv_flann=OFF
+  BUILD_opencv_gpu=OFF
+  BUILD_opencv_java=OFF
+  BUILD_opencv_legacy=OFF
+  BUILD_opencv_ml=OFF
+  BUILD_opencv_nonfree=OFF
+  BUILD_opencv_objdetect=OFF
+  BUILD_opencv_ocl=OFF
+  BUILD_opencv_photo=OFF
+  BUILD_opencv_python=OFF
+  BUILD_opencv_shape=OFF
+  BUILD_opencv_stitching=OFF
+  BUILD_opencv_superres=OFF
+  BUILD_opencv_ts=OFF
+  BUILD_opencv_videostab=OFF
+  BUILD_opencv_viz=OFF
+  BUILD_opencv_world=OFF
+  BUILD_opencv_apps=OFF  
+  
   BUILD_DOCS=OFF
   BUILD_TESTS=OFF
   BUILD_PERF_TESTS=OFF
-  BUILD_opencv_apps=OFF
   BUILD_EXAMPLES=OFF
   ENABLE_NEON=OFF
   BUILD_ANDROID_SERVICE=OFF
@@ -78,10 +117,13 @@ set(OPENCV_CMAKE_ARGS
   WITH_GPHOTO2=OFF        # "Include gPhoto2 library support"
   )
 
-if(APPLE)
-  set(ogles_gpgpu_opencv_version "3.0.0-p11")
-else()
-  set(ogles_gpgpu_opencv_version "${HUNTER_OpenCV_VERSION}")
+#hunter_config(OpenCV VERSION 3.0.0-p11 CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
+
+hunter_config(OpenCV VERSION ${HUNTER_OpenCV_VERSION} CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
+
+hunter_config(aglet GIT_SUBMODULE "3rdparty/aglet") # TODO: upstream hunter package
+
+if(OGLES_GPGPU_USE_OSMESA)
+  hunter_config(glfw VERSION ${HUNTER_glfw_VERSION} CMAKE_ARGS GLFW_USE_OSMESA=ON)
 endif()
 
-hunter_config(OpenCV VERSION ${ogles_gpgpu_opencv_version} CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,10 +1,12 @@
 set(OPENCV_CMAKE_ARGS
 
-  BUILD_opencv_imgcodecs=ON  
+  BUILD_opencv_core=ON
   BUILD_opencv_imgproc=ON
-  BUILD_opencv_video=ON
-  BUILD_opencv_videoio=ON
-  BUILD_opencv_highgui=ON  
+  
+  BUILD_opencv_imgcodecs=OFF
+  BUILD_opencv_video=OFF
+  BUILD_opencv_videoio=OFF
+  BUILD_opencv_highgui=OFF  
   
   BUILD_opencv_calib3d=OFF
   BUILD_opencv_contrib=OFF
@@ -54,10 +56,10 @@ set(OPENCV_CMAKE_ARGS
   ANDROID_EXAMPLES_WITH_LIBS=OFF    # "Build binaries of Android examples with native libraries"
 
   ### Custom ARGS ###
-  WITH_PNG=ON             # "Include PNG support"
+  WITH_PNG=OFF             # "Include PNG support"
   WITH_TIFF=OFF           # "Include TIFF support"
-  WITH_JASPER=ON          # "Include JPEG2K support"
-  WITH_JPEG=ON            # "Include JPEG support"
+  WITH_JASPER=OFF          # "Include JPEG2K support"
+  WITH_JPEG=OFF            # "Include JPEG support"
 
   WITH_OPENCL=NO
   HAVE_OPENCL=NO
@@ -117,11 +119,8 @@ set(OPENCV_CMAKE_ARGS
   WITH_GPHOTO2=OFF        # "Include gPhoto2 library support"
   )
 
-#hunter_config(OpenCV VERSION 3.0.0-p11 CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
-
+# Try to build very small OpenCV to support unit tests
 hunter_config(OpenCV VERSION ${HUNTER_OpenCV_VERSION} CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
-
-hunter_config(aglet GIT_SUBMODULE "3rdparty/aglet") # TODO: upstream hunter package
 
 if(OGLES_GPGPU_USE_OSMESA)
   hunter_config(glfw VERSION ${HUNTER_glfw_VERSION} CMAKE_ARGS GLFW_USE_OSMESA=ON)

--- a/cmake/modules/CommonFindMod.cmake
+++ b/cmake/modules/CommonFindMod.cmake
@@ -2,7 +2,7 @@
 #  Software License, Version 1.0. (See accompanying file
 #  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
-macro(drishti_common_find_module PREFIX PC_NAME HEADER LIBRARY)
+macro(ogles_gpgpu_common_find_module PREFIX PC_NAME HEADER LIBRARY)
   unset(${PREFIX}_FOUND)
   unset(${PREFIX}_DEFINITIONS)
   unset(${PREFIX}_INCLUDE_DIRS)
@@ -87,7 +87,7 @@ macro(drishti_common_find_module PREFIX PC_NAME HEADER LIBRARY)
         "${PROJECT_BINARY_DIR}/ext_lib"
         "${PROJECT_BINARY_DIR}/ext_lib/test_${PREFIX}.cpp"
         COMPILE_DEFINITIONS
-        "${DRISHTI_CPP_STD_COMPILER_SWITCH} ${${PREFIX}_DEFINITIONS}"
+        "${OGLES_GPGPU_CPP_STD_COMPILER_SWITCH} ${${PREFIX}_DEFINITIONS}"
         CMAKE_FLAGS
         "-DINCLUDE_DIRECTORIES:STRING=${${PREFIX}_INCLUDE_DIRS} "
         "-DLIBRARY_DIRECTORIES:STRING=${${PREFIX}_LIBRARY_DIRS} "

--- a/cmake/modules/FindAndroid.cmake
+++ b/cmake/modules/FindAndroid.cmake
@@ -4,4 +4,4 @@
 #
 
 include(CommonFindMod)
-drishti_common_find_module(ANDROID android android/api-level.h android)
+ogles_gpgpu_common_find_module(ANDROID android android/api-level.h android)

--- a/cmake/modules/FindEGL.cmake
+++ b/cmake/modules/FindEGL.cmake
@@ -4,4 +4,4 @@
 #
 
 include(CommonFindMod)
-drishti_common_find_module(EGL egl EGL/egl.h EGL)
+ogles_gpgpu_common_find_module(EGL egl EGL/egl.h EGL)

--- a/cmake/modules/FindLog.cmake
+++ b/cmake/modules/FindLog.cmake
@@ -4,4 +4,4 @@
 #
 
 include(CommonFindMod)
-drishti_common_find_module(LOG log android/log.h log)
+ogles_gpgpu_common_find_module(LOG log android/log.h log)

--- a/cmake/modules/FindOpenGLES2.cmake
+++ b/cmake/modules/FindOpenGLES2.cmake
@@ -4,4 +4,4 @@
 #
 
 include(CommonFindMod)
-drishti_common_find_module(OpenGLES2 GLESv2 GLES2/gl2.h GLESv2)
+ogles_gpgpu_common_find_module(OpenGLES2 GLESv2 GLES2/gl2.h GLESv2)

--- a/ogles_gpgpu/CMakeLists.txt
+++ b/ogles_gpgpu/CMakeLists.txt
@@ -38,6 +38,15 @@ else()
 
   if(OGLES_GPGPU_USE_OSMESA)
 
+    # Note: Currently OSMesa is used for CPU OpenGL shader processing,
+    # primarily to supporting testing on HW platforms that lack GPU
+    # resources.  This is currently tested on Linux, although this could
+    # in theory be tested on other platforms.  There are a number of
+    # platform specific optimizations for iOS and Android that would
+    # have to be made option in order to support this.  For now the
+    # OSMESA option is excluded from those platforms in the CMake control
+    # logic.
+    
     find_library(OSMESA_LIBRARY OSMesa)
     if(NOT OSMESA_LIBRARY)
       message(FATAL_ERROR "OGLES_GPGPU was configured to use OSMesa, but the library could not be found")
@@ -56,12 +65,21 @@ else()
     endif()
     mark_as_advanced(OSMESA_LIBRARY GLAPI_LIBRARY EGL_LIBRARY)
 
-    target_link_libraries(ogles_gpgpu PUBLIC ${OSMESA_LIBRARY} ${GLAPI_LIBRARY} ${EGL_LIBRARY})
+    # Create a new target specfiically for OSMesa (cpu shader) based testing 
+    # (We will never create ogles_gpgpu libraries w/ CPU OpenGL processing.)
+    add_library(ogles_gpgpu_cpu ${OGLES_GPGPU_SRCS})
 
-  else()
-    find_package(OpenGL REQUIRED)
-    target_link_libraries(ogles_gpgpu PUBLIC OpenGL::GL)
+    if(OGLES_GPGPU_VERBOSE)
+      target_compile_definitions(ogles_gpgpu_cpu PUBLIC OGLES_GPGPU_VERBOSE=1)
+    endif()    
+
+    target_link_libraries(ogles_gpgpu_cpu PUBLIC ${OSMESA_LIBRARY} ${GLAPI_LIBRARY} ${EGL_LIBRARY})
+    
   endif()
+
+  # Link epxported ogles_gpgpu with the stanrda OpenGL lib
+  find_package(OpenGL REQUIRED)
+  target_link_libraries(ogles_gpgpu PUBLIC OpenGL::GL)
   
   if(MSVC)
     # ogles_gpgpu/platform/opengl/gl_includes.h: #include <gl/glew.h>
@@ -73,7 +91,7 @@ else()
   endif()
 endif()
   
-set_property(TARGET ${library} PROPERTY FOLDER "libs/ogles_gpgpu")
+set_property(TARGET ogles_gpgpu PROPERTY FOLDER "libs/ogles_gpgpu")
 target_include_directories(
     ogles_gpgpu PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>"
 )

--- a/ogles_gpgpu/CMakeLists.txt
+++ b/ogles_gpgpu/CMakeLists.txt
@@ -16,6 +16,7 @@ if(APPLE)
     target_link_libraries(ogles_gpgpu PUBLIC
       "-framework ImageIO"
       "-framework CoreFoundation"
+      "-framework CoreVideo"
       "-framework Foundation" # NSLog
       "-framework OpenGLES"      
       )    

--- a/ogles_gpgpu/CMakeLists.txt
+++ b/ogles_gpgpu/CMakeLists.txt
@@ -58,11 +58,6 @@ else()
 
     target_link_libraries(ogles_gpgpu PUBLIC ${OSMESA_LIBRARY} ${GLAPI_LIBRARY} ${EGL_LIBRARY})
 
-    message("OSMESA_LIBRARY = ${OSMESA_LIBRARY}")
-    message("GLAPI_LIBRARY = ${GLAPI_LIBRARY}")
-    message("EGL_LIBRARY = ${EGL_LIBRARY}")
-    message("OSMESA_PATH = ${OSMESA_PATH}")
-
   else()
     find_package(OpenGL REQUIRED)
     target_link_libraries(ogles_gpgpu PUBLIC OpenGL::GL)

--- a/ogles_gpgpu/CMakeLists.txt
+++ b/ogles_gpgpu/CMakeLists.txt
@@ -74,6 +74,11 @@ else()
     endif()    
 
     target_link_libraries(ogles_gpgpu_cpu PUBLIC ${OSMESA_LIBRARY} ${GLAPI_LIBRARY} ${EGL_LIBRARY})
+
+    set_property(TARGET ogles_gpgpu_cpu PROPERTY FOLDER "libs/ogles_gpgpu")
+    target_include_directories(
+      ogles_gpgpu_cpu PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>"
+      )    
     
   endif()
 

--- a/ogles_gpgpu/CMakeLists.txt
+++ b/ogles_gpgpu/CMakeLists.txt
@@ -1,28 +1,87 @@
 include(sugar_include)
 sugar_include(.)
 
-add_library(ogles_gpgpu ${OGLES_GPGPU_SRCS} )
+add_library(ogles_gpgpu ${OGLES_GPGPU_SRCS})
 
 if(OGLES_GPGPU_VERBOSE)
   target_compile_definitions(ogles_gpgpu PUBLIC OGLES_GPGPU_VERBOSE=1)
 endif()
 
-if(ANDROID)
+## #################################################################
+## Dependencies - OpenGL stuff
+## #################################################################
+
+if(APPLE)
+  if(IOS)
+    target_link_libraries(ogles_gpgpu PUBLIC
+      "-framework ImageIO"
+      "-framework CoreFoundation"
+      "-framework Foundation" # NSLog
+      "-framework OpenGLES"      
+      )    
+  else()
+    target_link_libraries(ogles_gpgpu PUBLIC
+      "-framework ImageIO"
+      "-framework CoreFoundation"
+      "-framework CoreVideo"
+      "-framework OpenGL"
+      )
+  endif()
+elseif(ANDROID)
+  find_package(Android REQUIRED)
+  find_package(Log REQUIRED)
+  find_package(EGL REQUIRED)
+  find_package(OpenGLES2 REQUIRED)
   target_link_libraries(ogles_gpgpu PUBLIC log android EGL GLESv2)
   target_compile_definitions(ogles_gpgpu PUBLIC EGL_EGLEXT_PROTOTYPES GL_GLEXT_PROTOTYPES)
-endif()
+else()
 
-if(MSVC)
-  target_link_libraries(ogles_gpgpu glew::glew)
-  target_compile_definitions(ogles_gpgpu PUBLIC NOMINMAX) # avoid std::{min,max} conflicts
-  target_compile_definitions(ogles_gpgpu PUBLIC _USE_MATH_DEFINES) # M_PI, etc
-endif()
+  if(OGLES_GPGPU_USE_OSMESA)
 
+    find_library(OSMESA_LIBRARY OSMesa)
+    if(NOT OSMESA_LIBRARY)
+      message(FATAL_ERROR "OGLES_GPGPU was configured to use OSMesa, but the library could not be found")
+    endif()
+
+    get_filename_component(OSMESA_PATH ${OSMESA_LIBRARY} DIRECTORY)
+
+    find_library(GLAPI_LIBRARY glapi HINTS ${OSMESA_PATH} PATHS ${OSMESA_PATH})
+    if(NOT GLAPI_LIBRARY)
+      message(FATAL_ERROR "OGLES_GPGPU was configured to use OSMesa, but the GLAPI dependency was not found")
+    endif()
+
+    find_library(EGL_LIBRARY EGL HINTS ${OSMESA_PATH} PATHS ${OSMESA_PATH})
+    if(NOT EGL_LIBRARY)
+      message(FATAL_ERROR "EGL_LIBRARY was configured to use OSMesa, but the EGL dependency was not found")
+    endif()
+    mark_as_advanced(OSMESA_LIBRARY GLAPI_LIBRARY EGL_LIBRARY)
+
+    target_link_libraries(ogles_gpgpu PUBLIC ${OSMESA_LIBRARY} ${GLAPI_LIBRARY} ${EGL_LIBRARY})
+
+    message("OSMESA_LIBRARY = ${OSMESA_LIBRARY}")
+    message("GLAPI_LIBRARY = ${GLAPI_LIBRARY}")
+    message("EGL_LIBRARY = ${EGL_LIBRARY}")
+    message("OSMESA_PATH = ${OSMESA_PATH}")
+
+  else()
+    find_package(OpenGL REQUIRED)
+    target_link_libraries(ogles_gpgpu PUBLIC OpenGL::GL)
+  endif()
+  
+  if(MSVC)
+    # ogles_gpgpu/platform/opengl/gl_includes.h: #include <gl/glew.h>
+    hunter_add_package(glew)
+    find_package(glew CONFIG REQUIRED)
+    target_link_libraries(ogles_gpgpu PUBLIC glew::glew)
+    target_compile_definitions(ogles_gpgpu PUBLIC NOMINMAX) # avoid std::{min,max} conflicts
+    target_compile_definitions(ogles_gpgpu PUBLIC _USE_MATH_DEFINES) # M_PI, etc
+  endif()
+endif()
+  
 set_property(TARGET ${library} PROPERTY FOLDER "libs/ogles_gpgpu")
 target_include_directories(
     ogles_gpgpu PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>"
 )
-
 
 ## #################################################################
 ## Testing: 

--- a/ogles_gpgpu/common/common_includes.h
+++ b/ogles_gpgpu/common/common_includes.h
@@ -11,11 +11,12 @@
  * Common header includes
  */
 
-#include <iostream>
 #include <cassert>
+#include <iostream>
 
 // Need initial preprocessor pass for nested includes
 
+// clang-format off
 #if __APPLE__
 #  include "TargetConditionals.h"
 #  if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
@@ -46,6 +47,7 @@
 #  include "../platform/opengl/gl_includes.h"
 #  include "macros.h"
 #endif
+// clang-format on
 
 /* #ifdef __APPLE__ */
 /*     #include "../platform/ios/gl_includes.h" */

--- a/ogles_gpgpu/common/core.h
+++ b/ogles_gpgpu/common/core.h
@@ -15,8 +15,8 @@
 #define OGLES_GPGPU_COMMON_CORE
 
 #include "common_includes.h"
-#include "proc/base/procinterface.h"
 #include "gl/memtransfer.h"
+#include "proc/base/procinterface.h"
 
 #include <list>
 #include <vector>
@@ -37,7 +37,7 @@ public:
     /**
      * Get singleton instance.
      */
-    static Core *getInstance();
+    static Core* getInstance();
 
     /**
      * Destroy singleton instance.
@@ -59,7 +59,7 @@ public:
      * Note: OpenGL context must be initialized before a ProcInterface object
      * was created!
      */
-    void addProcToPipeline(ProcInterface *proc);
+    void addProcToPipeline(ProcInterface* proc);
 
     /**
      * Create an object that renders the last processor's output to the screen.
@@ -70,7 +70,7 @@ public:
      * Note: Must be called after last addProcToPipeline() call and before
      * init() / prepare()!
      */
-    Disp *createRenderDisplay(int dispW = 0, int dispH = 0, RenderOrientation orientation = RenderOrientationStd);
+    Disp* createRenderDisplay(int dispW = 0, int dispH = 0, RenderOrientation orientation = RenderOrientationStd);
 
     /**
      * Initialize OpenGL settings and the pipeline.
@@ -80,7 +80,7 @@ public:
      * Note OpenGL context must be initialized before the pipeline was
      * defined!
      */
-    void init(void *glContext = NULL);
+    void init(void* glContext = NULL);
 
     /**
      * Prepare the processing pipeline for incoming frames of size <inW> x <inH>
@@ -95,19 +95,19 @@ public:
     /**
      * Return the render display object as weak ref.
      */
-    Disp *getRenderDisplay() const {
+    Disp* getRenderDisplay() const {
         return renderDisp;
     }
 
     /**
      * Get pointer to input memory transfer handler
      */
-    MemTransfer *getInputMemTransfer() const;
+    MemTransfer* getInputMemTransfer() const;
 
     /**
      * Get pointer to output memory transfer handler
      */
-    MemTransfer *getOutputMemTransfer() const;
+    MemTransfer* getOutputMemTransfer() const;
 
     /**
      * Use mipmaps: <use>.
@@ -132,7 +132,7 @@ public:
     /**
      * Set input as RGBA byte data of size <w> x <h>.
      */
-    void setInputData(const unsigned char *data);
+    void setInputData(const unsigned char* data);
 
     /**
      * Process input data by executing the GPGPU processors defined in
@@ -151,13 +151,12 @@ public:
     /**
      * Get input as bytes. Will copy the input texture from the GPU to <buf>.
      */
-    void getInputData(unsigned char *buf);
-
+    void getInputData(unsigned char* buf);
 
     /**
      * Get output as bytes. Will copy the output texture from the GPU to <buf>.
      */
-    void getOutputData(unsigned char *buf);
+    void getOutputData(unsigned char* buf);
 
     /**
      * Get output frame width.
@@ -176,7 +175,7 @@ public:
     /**
      * Get pointer to OpenGL context (platform specific type).
      */
-    void *getGLContextPtr() const {
+    void* getGLContextPtr() const {
         return glContextPtr;
     }
 
@@ -214,7 +213,7 @@ private:
     /**
      * Empty copy constructor.
      */
-    Core (const Core&) {}
+    Core(const Core&) {}
 
     /**
      * Check which OpenGL extensions are available.
@@ -229,36 +228,34 @@ private:
      */
     void cleanup();
 
+    static Core* instance; // singleton instance
 
-    static Core *instance;  // singleton instance
+    void* glContextPtr; // pointer to OpenGL context (platform specific type), weak ref.
 
-    void *glContextPtr;     // pointer to OpenGL context (platform specific type), weak ref.
+    list<ProcInterface*> pipeline; // contains weak refs to ProcBase objects
 
-    list<ProcInterface *> pipeline;  // contains weak refs to ProcBase objects
+    ProcInterface* firstProc; // pointer to first processor in pipeline
+    ProcInterface* lastProc; // pointer to last processor in pipeline
 
-    ProcInterface *firstProc;    // pointer to first processor in pipeline
-    ProcInterface *lastProc;     // pointer to last processor in pipeline
+    Disp* renderDisp; // render-to-display object. strong ref.
 
-    Disp *renderDisp;       // render-to-display object. strong ref.
+    bool initialized; // pipeline initialized?
+    bool prepared; // input prepared?
 
-    bool initialized;       // pipeline initialized?
-    bool prepared;          // input prepared?
+    bool useMipmaps; // use mipmaps?
+    bool glExtNPOTMipmaps; // hardware supports NPOT mipmapping?
 
-    bool useMipmaps;        // use mipmaps?
-    bool glExtNPOTMipmaps;  // hardware supports NPOT mipmapping?
+    bool inputSizeIsPOT; // input frame size is POT?
 
-    bool inputSizeIsPOT;    // input frame size is POT?
+    int inputFrameW; // input frame width
+    int inputFrameH; // input frame height
+    int outputFrameW; // output frame width
+    int outputFrameH; // output frame width
 
-    int inputFrameW;        // input frame width
-    int inputFrameH;        // input frame height
-    int outputFrameW;       // output frame width
-    int outputFrameH;       // output frame width
-
-    GLuint inputTexId;      // input texture id
-    GLenum inputTexTarget;  // input texture target
-    GLuint outputTexId;     // output texture id
+    GLuint inputTexId; // input texture id
+    GLenum inputTexTarget; // input texture target
+    GLuint outputTexId; // output texture id
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/common/gl/fbo.cpp
+++ b/ogles_gpgpu/common/gl/fbo.cpp
@@ -98,9 +98,9 @@ void FBO::createAttachedTex(int w, int h, bool genMipmap, GLenum attachment, GLe
 
     // bind it to FBO
     glFramebufferTexture2D(GL_FRAMEBUFFER,
-                           attachment,
-                           target,
-                           attachedTexId, 0);
+        attachment,
+        target,
+        attachedTexId, 0);
 
     GLenum fboStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 
@@ -109,14 +109,14 @@ void FBO::createAttachedTex(int w, int h, bool genMipmap, GLenum attachment, GLe
         attachedTexId = 0;
     } else {
         OG_LOGINF("FBO", "FBO with ID %d: created attached texture %d of size %dx%d (mipmap: %d)",
-                  id, attachedTexId, w, h, genMipmap);
+            id, attachedTexId, w, h, genMipmap);
     }
 
     // unbind FBO
     unbind();
 }
 
-void FBO::readBuffer(unsigned char *buf) {
+void FBO::readBuffer(unsigned char* buf) {
     assert(memTransfer && attachedTexId > 0 && texW > 0 && texH > 0);
 
     // bind the FBO
@@ -129,7 +129,7 @@ void FBO::readBuffer(unsigned char *buf) {
     unbind();
 }
 
-void FBO::readBuffer(FrameDelegate &delegate) {
+void FBO::readBuffer(FrameDelegate& delegate) {
     assert(memTransfer && attachedTexId > 0 && texW > 0 && texH > 0);
 
     // bind the FBO

--- a/ogles_gpgpu/common/gl/fbo.h
+++ b/ogles_gpgpu/common/gl/fbo.h
@@ -27,7 +27,6 @@ class Core;
  */
 class FBO {
 public:
-
     using FrameDelegate = MemTransfer::FrameDelegate;
 
     /**
@@ -89,18 +88,18 @@ public:
      * Will create a framebuffer output texture with texture id <attachedTexId>
      * and will bind it to this FBO.
      */
-    virtual void createAttachedTex(int w, int h, bool genMipmap = false, GLenum attachment = GL_COLOR_ATTACHMENT0, GLenum target=GL_TEXTURE_2D);
+    virtual void createAttachedTex(int w, int h, bool genMipmap = false, GLenum attachment = GL_COLOR_ATTACHMENT0, GLenum target = GL_TEXTURE_2D);
 
     /**
      * Copy the framebuffer data which was written to the framebuffer texture back to
      * main memory at <buf>.
      */
-    virtual void readBuffer(unsigned char *buf);
+    virtual void readBuffer(unsigned char* buf);
 
     /**
      * Call the delegate on framebuffer data which was written to the framebuffer texture.
      */
-    virtual void readBuffer(FrameDelegate &delegate);
+    virtual void readBuffer(FrameDelegate& delegate);
 
     /**
      * Free the framebuffer.
@@ -129,7 +128,7 @@ public:
     /**
      * Get MemTransfer object associated with this FBO.
      */
-    MemTransfer *getMemTransfer() const {
+    MemTransfer* getMemTransfer() const {
         return memTransfer;
     }
 
@@ -139,19 +138,17 @@ protected:
      */
     virtual void generateIds();
 
+    Core* core; // Core singleton
 
-    Core *core;                 // Core singleton
+    MemTransfer* memTransfer; // MemTransfer object associated with this FBO
 
-    MemTransfer *memTransfer;   // MemTransfer object associated with this FBO
+    GLuint id; // OpenGL FBO id
+    GLuint glTexUnit; // GL texture unit (to be used in glActiveTexture()) for output texture
+    GLuint attachedTexId; // output texture id
 
-    GLuint id;                  // OpenGL FBO id
-    GLuint glTexUnit;           // GL texture unit (to be used in glActiveTexture()) for output texture
-    GLuint attachedTexId;       // output texture id
-
-    int texW;   // output texture width
-    int texH;   // output texture height
+    int texW; // output texture width
+    int texH; // output texture height
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/common/gl/memtransfer.cpp
+++ b/ogles_gpgpu/common/gl/memtransfer.cpp
@@ -22,9 +22,9 @@ bool MemTransfer::initPlatformOptimizations() {
 #pragma mark constructor/deconstructor
 
 #if ANDROID
-#  define DFLT_TEXTURE_FORMAT GL_RGBA
+#define DFLT_TEXTURE_FORMAT GL_RGBA
 #else
-#  define DFLT_TEXTURE_FORMAT GL_BGRA
+#define DFLT_TEXTURE_FORMAT GL_BGRA
 #endif
 
 MemTransfer::MemTransfer() {
@@ -46,14 +46,14 @@ MemTransfer::~MemTransfer() {
 
 #pragma mark public methods
 
-GLuint MemTransfer::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat, void *inputDataPtr) {
+GLuint MemTransfer::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat, void* inputDataPtr) {
     assert(initialized && inTexW > 0 && inTexH > 0);
 
     if ((inputDataPtr == nullptr) && (inputW == inTexW) && (inputH == inTexH) && (inputPixelFormat == inputPxFormat)) {
         return inputTexId; // no change
     }
 
-    if (preparedInput) {    // already prepared -- release buffers!
+    if (preparedInput) { // already prepared -- release buffers!
         releaseInput();
     }
 
@@ -85,7 +85,7 @@ GLuint MemTransfer::prepareOutput(int outTexW, int outTexH) {
         return outputTexId; // no change
     }
 
-    if (preparedOutput) {    // already prepared -- release buffers!
+    if (preparedOutput) { // already prepared -- release buffers!
         releaseOutput();
     }
 
@@ -110,10 +110,10 @@ GLuint MemTransfer::prepareOutput(int outTexW, int outTexH) {
 
     // create empty texture space on GPU
     glTexImage2D(GL_TEXTURE_2D, 0,
-                 GL_RGBA,
-                 outTexW, outTexH, 0,
-                 rgbFormat, GL_UNSIGNED_BYTE,
-                 NULL);	// we do not need to pass texture data -> it will be generated!
+        GL_RGBA,
+        outTexW, outTexH, 0,
+        rgbFormat, GL_UNSIGNED_BYTE,
+        NULL); // we do not need to pass texture data -> it will be generated!
 
     Tools::checkGLErr("MemTransfer", "fbo texture creation");
 
@@ -137,11 +137,11 @@ void MemTransfer::releaseOutput() {
     }
 }
 
-void MemTransfer::toGPU(const unsigned char *buf) {
+void MemTransfer::toGPU(const unsigned char* buf) {
     assert(preparedInput && inputTexId > 0 && buf);
 
     // set input texture
-    glBindTexture(GL_TEXTURE_2D, inputTexId);	// bind input texture
+    glBindTexture(GL_TEXTURE_2D, inputTexId); // bind input texture
 
     // copy data as texture to GPU (tested: OS X)
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
@@ -153,7 +153,7 @@ void MemTransfer::toGPU(const unsigned char *buf) {
     setCommonTextureParams(0);
 }
 
-void MemTransfer::fromGPU(unsigned char *buf) {
+void MemTransfer::fromGPU(unsigned char* buf) {
     assert(preparedOutput && outputTexId > 0 && buf);
 
     glBindTexture(GL_TEXTURE_2D, outputTexId);
@@ -166,7 +166,7 @@ void MemTransfer::fromGPU(unsigned char *buf) {
 }
 
 // The zero copy fromGPU() call is not possibly with generic glReadPixels() access
-void MemTransfer::fromGPU(FrameDelegate &delegate) {
+void MemTransfer::fromGPU(FrameDelegate& delegate) {
     assert(false);
 }
 

--- a/ogles_gpgpu/common/gl/memtransfer.h
+++ b/ogles_gpgpu/common/gl/memtransfer.h
@@ -26,8 +26,7 @@ namespace ogles_gpgpu {
  */
 class MemTransfer {
 public:
-
-    typedef std::function<void(const Size2d &size, const void *pixels, size_t rowStride)> FrameDelegate;
+    typedef std::function<void(const Size2d& size, const void* pixels, size_t rowStride)> FrameDelegate;
 
     /**
      * Constructor
@@ -49,7 +48,7 @@ public:
     /**
      * Prepare for input frames of size <inTexW>x<inTexH>. Return a texture id for the input frames.
      */
-    virtual GLuint prepareInput(int inTexW, int inTexH, GLenum inputPxFormat = GL_RGBA, void *inputDataPtr = NULL);
+    virtual GLuint prepareInput(int inTexW, int inTexH, GLenum inputPxFormat = GL_RGBA, void* inputDataPtr = NULL);
 
     /**
      * Prepare for output frames of size <outTexW>x<outTexH>. Return a texture id for the output frames.
@@ -102,17 +101,17 @@ public:
     /**
      * Map data in <buf> to GPU.
      */
-    virtual void toGPU(const unsigned char *buf);
+    virtual void toGPU(const unsigned char* buf);
 
     /**
      * Map data from GPU to <buf>
      */
-    virtual void fromGPU(unsigned char *buf);
+    virtual void fromGPU(unsigned char* buf);
 
     /**
      * Callback for data in GPU.
      */
-    virtual void fromGPU(FrameDelegate &delegate);
+    virtual void fromGPU(FrameDelegate& delegate);
 
     /**
      * Get output pixel format (i.e., GL_BGRA or GL_RGBA)
@@ -153,30 +152,29 @@ protected:
      * bind texture if <texId> > 0 and
      * set clamping (allows NPOT textures)
      */
-    virtual void setCommonTextureParams(GLuint texId, GLenum target=GL_TEXTURE_2D);
+    virtual void setCommonTextureParams(GLuint texId, GLenum target = GL_TEXTURE_2D);
 
-    bool initialized;       // is initialized?
+    bool initialized; // is initialized?
 
-    bool preparedInput;     // input is prepared?
-    bool preparedOutput;    // output is prepared?
+    bool preparedInput; // input is prepared?
+    bool preparedOutput; // output is prepared?
 
-    int inputW;             // input texture width
-    int inputH;             // input texture height
-    int outputW;            // output texture width
-    int outputH;            // output texture heights
+    int inputW; // input texture width
+    int inputH; // input texture height
+    int outputW; // output texture width
+    int outputH; // output texture heights
 
-    GLuint inputTexId;      // input texture id
-    GLuint outputTexId;     // output texture id
+    GLuint inputTexId; // input texture id
+    GLuint outputTexId; // output texture id
 
     GLuint luminanceTexId = 0;
     GLuint chrominanceTexId = 0;
 
-    GLenum inputPixelFormat;    // input texture pixel format
+    GLenum inputPixelFormat; // input texture pixel format
     GLenum outputPixelFormat;
 
     bool useRawPixels = false;
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/common/gl/memtransfer_factory.cpp
+++ b/ogles_gpgpu/common/gl/memtransfer_factory.cpp
@@ -17,35 +17,35 @@
 //#endif
 
 #ifdef OGLES_GPGPU_IOS
-#  include "../../platform/ios/memtransfer_ios.h"
+#include "../../platform/ios/memtransfer_ios.h"
 #elif OGLES_GPGPU_OSX
-#  include "../../platform/osx/memtransfer_osx.h"
+#include "../../platform/osx/memtransfer_osx.h"
 #elif OGLES_GPGPU_ANDROID
-#  include "../../platform/android/memtransfer_android.h"
+#include "../../platform/android/memtransfer_android.h"
 #else
-#  include "../../platform/opengl/memtransfer_generic.h"
+#include "../../platform/opengl/memtransfer_generic.h"
 #endif
 
 using namespace ogles_gpgpu;
 
 bool MemTransferFactory::usePlatformOptimizations = false;
 
-MemTransfer *MemTransferFactory::createInstance() {
-    MemTransfer *instance = NULL;
+MemTransfer* MemTransferFactory::createInstance() {
+    MemTransfer* instance = NULL;
 
-    if (usePlatformOptimizations) {   // create specialized instance
+    if (usePlatformOptimizations) { // create specialized instance
 #ifdef OGLES_GPGPU_IOS
-        instance = (MemTransfer *)new MemTransferIOS();
+        instance = (MemTransfer*)new MemTransferIOS();
 #elif OGLES_GPGPU_OSX
-        instance = (MemTransfer *)new MemTransferOSX();
+        instance = (MemTransfer*)new MemTransferOSX();
 #elif OGLES_GPGPU_ANDROID
-        instance = (MemTransfer *)new MemTransferAndroid();
+        instance = (MemTransfer*)new MemTransferAndroid();
 #else
-        instance = (MemTransfer *)new MemTransfer();
+        instance = (MemTransfer*)new MemTransfer();
 #endif
     }
 
-    if (!instance) {    // create default instance
+    if (!instance) { // create default instance
         instance = new MemTransfer();
     }
 

--- a/ogles_gpgpu/common/gl/memtransfer_factory.h
+++ b/ogles_gpgpu/common/gl/memtransfer_factory.h
@@ -29,7 +29,7 @@ public:
     /**
      * Create a new MemTransfer instance.
      */
-    static MemTransfer *createInstance();
+    static MemTransfer* createInstance();
 
     /**
      * Try to enable platform optimizations. Returns true on success, else false.
@@ -37,9 +37,8 @@ public:
     static bool tryEnablePlatformOptimizations();
 
 private:
-    static bool usePlatformOptimizations;   // is true if tryEnablePlatformOptimizations() was called and succeeded
+    static bool usePlatformOptimizations; // is true if tryEnablePlatformOptimizations() was called and succeeded
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/common/gl/memtransfer_optimized.h
+++ b/ogles_gpgpu/common/gl/memtransfer_optimized.h
@@ -39,7 +39,7 @@ public:
      * The input buffer will be locked for reading AND writing, while the
      * output buffer will be locked for reading only.
      */
-    virtual void *lockBufferAndGetPtr(BufType bufType) = 0;
+    virtual void* lockBufferAndGetPtr(BufType bufType) = 0;
 
     /**
      * Unlock the input or output buffer.
@@ -53,7 +53,6 @@ public:
         glFlush();
     }
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/common/gl/shader.cpp
+++ b/ogles_gpgpu/common/gl/shader.cpp
@@ -23,7 +23,7 @@ Shader::~Shader() {
     }
 }
 
-bool Shader::buildFromSrc(const char *vshSrc, const char *fshSrc, const std::vector<Attribute> &attributes) {
+bool Shader::buildFromSrc(const char* vshSrc, const char* fshSrc, const std::vector<Attribute>& attributes) {
     programId = create(vshSrc, fshSrc, &vshId, &fshId, attributes);
 
     return (programId > 0);
@@ -33,11 +33,9 @@ void Shader::use() {
     glUseProgram(programId);
 }
 
-GLint Shader::getParam(ShaderParamType type, const char *name) const {
+GLint Shader::getParam(ShaderParamType type, const char* name) const {
     // get position according to type and name
-    GLint id = (type == ATTR) ?
-               glGetAttribLocation(programId, name) :
-               glGetUniformLocation(programId, name);
+    GLint id = (type == ATTR) ? glGetAttribLocation(programId, name) : glGetUniformLocation(programId, name);
 
     if (id < 0) {
         OG_LOGERR("Shader", "could not get parameter id for param %s", name);
@@ -47,7 +45,7 @@ GLint Shader::getParam(ShaderParamType type, const char *name) const {
 }
 
 GLuint
-Shader::create(const char *vshSrc, const char *fshSrc, GLuint *vshId, GLuint *fshId, const Attributes &attributes) {
+Shader::create(const char* vshSrc, const char* fshSrc, GLuint* vshId, GLuint* fshId, const Attributes& attributes) {
     *vshId = compile(GL_VERTEX_SHADER, vshSrc);
     *fshId = compile(GL_FRAGMENT_SHADER, fshSrc);
 
@@ -59,16 +57,16 @@ Shader::create(const char *vshSrc, const char *fshSrc, GLuint *vshId, GLuint *fs
         return 0;
     }
 
-    glAttachShader(programId, *vshId);   // add the vertex shader to program
-    glAttachShader(programId, *fshId);   // add the fragment shader to program
+    glAttachShader(programId, *vshId); // add the vertex shader to program
+    glAttachShader(programId, *fshId); // add the fragment shader to program
 
     // Bind attribute locations
     // this needs to be done prior to linking
-    for(int i = 0; i < attributes.size(); i++) {
+    for (int i = 0; i < attributes.size(); i++) {
         glBindAttribLocation(programId, attributes[i].first, attributes[i].second);
     }
 
-    glLinkProgram(programId);   // link both shaders to a full program
+    glLinkProgram(programId); // link both shaders to a full program
 
     // check link status
     GLint linkStatus;
@@ -78,7 +76,8 @@ Shader::create(const char *vshSrc, const char *fshSrc, GLuint *vshId, GLuint *fs
         GLchar infoLogBuf[1024];
         GLsizei infoLogLen;
         glGetProgramInfoLog(programId, 1024, &infoLogLen, infoLogBuf);
-        cerr << infoLogBuf << endl << endl;
+        cerr << infoLogBuf << endl
+             << endl;
 
         glDeleteProgram(programId);
 
@@ -88,7 +87,7 @@ Shader::create(const char *vshSrc, const char *fshSrc, GLuint *vshId, GLuint *fs
     return programId;
 }
 
-GLuint Shader::compile(GLenum type, const char *src) {
+GLuint Shader::compile(GLenum type, const char* src) {
     // create a shader
     GLuint shId = glCreateShader(type);
 
@@ -112,9 +111,11 @@ GLuint Shader::compile(GLenum type, const char *src) {
         GLchar infoLogBuf[1024];
         GLsizei infoLogLen;
         glGetShaderInfoLog(shId, 1024, &infoLogLen, infoLogBuf);
-        cerr << infoLogBuf << endl << endl;
+        cerr << infoLogBuf << endl
+             << endl;
         OG_LOGERR("Shader", "could not compile shader program. shader source:");
-        cerr << src << endl << endl;
+        cerr << src << endl
+             << endl;
 
         glDeleteShader(shId);
 

--- a/ogles_gpgpu/common/gl/shader.h
+++ b/ogles_gpgpu/common/gl/shader.h
@@ -16,13 +16,13 @@
 #include "../common_includes.h"
 
 #if OGLES_GPGPU_OPENGLES
-#  define OGLES_GPGPU_LOWP lowp
-#  define OGLES_GPGPU_MEDIUMP mediump
-#  define OGLES_GPGPU_HIGHP highp
+#define OGLES_GPGPU_LOWP lowp
+#define OGLES_GPGPU_MEDIUMP mediump
+#define OGLES_GPGPU_HIGHP highp
 #else
-#  define OGLES_GPGPU_LOWP
-#  define OGLES_GPGPU_MEDIUMP
-#  define OGLES_GPGPU_HIGHP
+#define OGLES_GPGPU_LOWP
+#define OGLES_GPGPU_MEDIUMP
+#define OGLES_GPGPU_HIGHP
 #endif
 
 namespace ogles_gpgpu {
@@ -37,8 +37,7 @@ typedef enum {
  */
 class Shader {
 public:
-
-    typedef std::pair<int, const char *> Attribute;
+    typedef std::pair<int, const char*> Attribute;
     typedef std::vector<Attribute> Attributes;
 
     /**
@@ -55,7 +54,7 @@ public:
      * Build an OpenGL shader object from vertex and fragment shader source code
      * <vshSrc> and <fshSrc>.
      */
-    bool buildFromSrc(const char *vshSrc, const char *fshSrc, const std::vector<Attribute> &attributes= {});
+    bool buildFromSrc(const char* vshSrc, const char* fshSrc, const std::vector<Attribute>& attributes = {});
 
     /**
      * Use the shader program.
@@ -66,7 +65,7 @@ public:
      * Get a shader parameter position for a parameter of type <type> and with
      * <name>.
      */
-    GLint getParam(ShaderParamType type, const char *name) const;
+    GLint getParam(ShaderParamType type, const char* name) const;
 
     /**
      * Get a shader parameter position for a parameter of type <type> and with
@@ -81,20 +80,17 @@ private:
      * Create a shader program from sources <vshSrc> and <fshSrc>. Save shader ids in
      * <vshId> and <fshId>.
      */
-    static GLuint create(const char *vshSrc, const char *fshSrc, GLuint *vshId, GLuint *fshId, const Attributes &attributes= {});
+    static GLuint create(const char* vshSrc, const char* fshSrc, GLuint* vshId, GLuint* fshId, const Attributes& attributes = {});
 
     /**
      * Compile a shader of type <type> and source <src> and return its id.
      */
-    static GLuint compile(GLenum type, const char *src);
+    static GLuint compile(GLenum type, const char* src);
 
-
-    GLuint programId;   // full shader program id
-    GLuint vshId;       // vertex shader id
-    GLuint fshId;       // fragment shader id
-
+    GLuint programId; // full shader program id
+    GLuint vshId; // vertex shader id
+    GLuint fshId; // fragment shader id
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/common/macros.h
+++ b/ogles_gpgpu/common/macros.h
@@ -14,13 +14,17 @@
 #define OG_TO_STR(x) OG_TO_STR_(x)
 
 #if defined(OGLES_GPGPU_VERBOSE)
-#  define OG_LOGINF(class_tag, fmt, ...) \
-	do { fprintf(stderr, "ogles_gpgpu::%s - %s:%d:%s(): " fmt "\n", class_tag, __FILE__, __LINE__, __func__, ##__VA_ARGS__); } while (0)
+#define OG_LOGINF(class_tag, fmt, ...)                                                                                      \
+    do {                                                                                                                    \
+        fprintf(stderr, "ogles_gpgpu::%s - %s:%d:%s(): " fmt "\n", class_tag, __FILE__, __LINE__, __func__, ##__VA_ARGS__); \
+    } while (0)
 #else
-#  define OG_LOGINF(class_tag, fmt, ...)
+#define OG_LOGINF(class_tag, fmt, ...)
 #endif
 
-#define OG_LOGERR(class_tag, fmt, ...) \
-	do { fprintf(stderr, "ogles_gpgpu::%s - %s:%d:%s(): " fmt "\n", class_tag, __FILE__, __LINE__, __func__, ##__VA_ARGS__); } while (0)
+#define OG_LOGERR(class_tag, fmt, ...)                                                                                      \
+    do {                                                                                                                    \
+        fprintf(stderr, "ogles_gpgpu::%s - %s:%d:%s(): " fmt "\n", class_tag, __FILE__, __LINE__, __func__, ##__VA_ARGS__); \
+    } while (0)
 
 #endif

--- a/ogles_gpgpu/common/proc/adapt_thresh.h
+++ b/ogles_gpgpu/common/proc/adapt_thresh.h
@@ -22,8 +22,8 @@ namespace ogles_gpgpu {
 class AdaptThreshProc : public MultiPassProc {
 public:
     AdaptThreshProc() {
-        AdaptThreshProcPass *adaptThreshPass1 = new AdaptThreshProcPass(1);
-        AdaptThreshProcPass *adaptThreshPass2 = new AdaptThreshProcPass(2);
+        AdaptThreshProcPass* adaptThreshPass1 = new AdaptThreshProcPass(1);
+        AdaptThreshProcPass* adaptThreshPass2 = new AdaptThreshProcPass(2);
 
         procPasses.push_back(adaptThreshPass1);
         procPasses.push_back(adaptThreshPass2);
@@ -32,7 +32,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "AdaptThreshProc";
     }
 };

--- a/ogles_gpgpu/common/proc/base/filterprocbase.cpp
+++ b/ogles_gpgpu/common/proc/base/filterprocbase.cpp
@@ -14,18 +14,18 @@
 using namespace ogles_gpgpu;
 using namespace std;
 
+// clang-format off
 const char *FilterProcBase::vshaderGPUImage = OG_TO_STR(
-            attribute vec4 position;
-            attribute vec4 inputTextureCoordinate;
-
-            varying vec2 textureCoordinate;
+attribute vec4 position;
+attribute vec4 inputTextureCoordinate;
+varying vec2 textureCoordinate;
 void main() {
     gl_Position = position;
     textureCoordinate = inputTextureCoordinate.xy;
-}
-        );
+});
+// clang-format on
 
-// *INDENT-OFF*
+// clang-format off
 const char *FilterProcBase::vshaderFilter3x3Src = OG_TO_STR(
 
     attribute vec4 position;
@@ -79,7 +79,7 @@ void main()
     vTexCoord = aTexCoord;
 }
 );
-// *INDENT-ON*
+// clang-format on
 
 #pragma mark public methods
 
@@ -93,9 +93,9 @@ void FilterProcBase::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int
     texId = id;
     texUnit = useTexUnit;
 
-    if (target != texTarget) {	// changed
-        if (fragShaderSrcForCompilation) {	// recreate shader with new texture target
-            auto vShaderSrc  = vertexShaderSrcForCompilation ? vertexShaderSrcForCompilation : vshaderDefault;
+    if (target != texTarget) { // changed
+        if (fragShaderSrcForCompilation) { // recreate shader with new texture target
+            auto vShaderSrc = vertexShaderSrcForCompilation ? vertexShaderSrcForCompilation : vshaderDefault;
             filterShaderSetup(vShaderSrc, fragShaderSrcForCompilation, target);
         }
         texTarget = target;
@@ -104,7 +104,7 @@ void FilterProcBase::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int
 
 #pragma mark protected methods
 
-void FilterProcBase::filterInit(const char *vShaderSrc, const char *fShaderSrc, RenderOrientation o) {
+void FilterProcBase::filterInit(const char* vShaderSrc, const char* fShaderSrc, RenderOrientation o) {
     // create shader object
     filterShaderSetup(vShaderSrc, fShaderSrc, texTarget);
 
@@ -115,7 +115,7 @@ void FilterProcBase::filterInit(const char *vShaderSrc, const char *fShaderSrc, 
     initTexCoordBuf(o);
 }
 
-void FilterProcBase::filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target) {
+void FilterProcBase::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target) {
     // create shader object
     ProcBase::createShader(vShaderSrc, fShaderSrc, target);
 
@@ -130,7 +130,6 @@ void FilterProcBase::filterShaderSetup(const char *vShaderSrc, const char *fShad
 }
 
 void FilterProcBase::getUniforms() {
-
 }
 
 /**
@@ -162,8 +161,8 @@ int FilterProcBase::render(int position) {
  * Initialize texture coordinate buffer according to member variable
  * <renderOrientation> or override member variable by <overrideRenderOrientation>.
  */
-const GLfloat * FilterProcBase::getTexCoordBuf(RenderOrientation o) {
-    const GLfloat *coordsPtr;
+const GLfloat* FilterProcBase::getTexCoordBuf(RenderOrientation o) {
+    const GLfloat* coordsPtr;
 
     switch (o) {
     default:
@@ -211,7 +210,7 @@ void FilterProcBase::filterRenderPrepare() {
 
     // set input texture
     glActiveTexture(GL_TEXTURE0 + texUnit);
-    glBindTexture(texTarget, texId);	// bind input texture
+    glBindTexture(texTarget, texId); // bind input texture
 
     // set common uniforms
     glUniform1i(shParamUInputTex, texUnit);
@@ -219,23 +218,24 @@ void FilterProcBase::filterRenderPrepare() {
 
 void FilterProcBase::filterRenderSetCoords() {
     // render to FBO
-    if (fbo) fbo->bind();
+    if (fbo)
+        fbo->bind();
 
     // set geometry
     glEnableVertexAttribArray(shParamAPos);
     glVertexAttribPointer(shParamAPos,
-                          OGLES_GPGPU_QUAD_COORDS_PER_VERTEX,
-                          GL_FLOAT,
-                          GL_FALSE,
-                          0,
-                          vertexBuf);
+        OGLES_GPGPU_QUAD_COORDS_PER_VERTEX,
+        GL_FLOAT,
+        GL_FALSE,
+        0,
+        vertexBuf);
 
     glVertexAttribPointer(shParamATexCoord,
-                          OGLES_GPGPU_QUAD_TEXCOORDS_PER_VERTEX,
-                          GL_FLOAT,
-                          GL_FALSE,
-                          0,
-                          texCoordBuf);
+        OGLES_GPGPU_QUAD_TEXCOORDS_PER_VERTEX,
+        GL_FLOAT,
+        GL_FALSE,
+        0,
+        texCoordBuf);
     glEnableVertexAttribArray(shParamATexCoord);
 }
 
@@ -249,7 +249,8 @@ void FilterProcBase::filterRenderCleanup() {
     glDisableVertexAttribArray(shParamAPos);
     glDisableVertexAttribArray(shParamATexCoord);
 
-    if (fbo) fbo->unbind();
+    if (fbo)
+        fbo->unbind();
 }
 
 int FilterProcBase::init(int inW, int inH, unsigned int order, bool prepareForExternalInput) {
@@ -269,4 +270,3 @@ int FilterProcBase::init(int inW, int inH, unsigned int order, bool prepareForEx
 
     return 1;
 }
-

--- a/ogles_gpgpu/common/proc/base/filterprocbase.h
+++ b/ogles_gpgpu/common/proc/base/filterprocbase.h
@@ -25,8 +25,9 @@ namespace ogles_gpgpu {
  */
 class FilterProcBase : public ProcBase {
 public:
-    FilterProcBase() : ProcBase(),
-        fragShaderSrcForCompilation(NULL) {
+    FilterProcBase()
+        : ProcBase()
+        , fragShaderSrcForCompilation(NULL) {
     }
 
     /**
@@ -44,10 +45,9 @@ public:
      * Abstract method.  The optional position parameter is used
      * to specify the input index for multi-texture filters.
      */
-    virtual int render(int position=0);
+    virtual int render(int position = 0);
 
 protected:
-
     /**
      * Perform a standard shader initialization.
      */
@@ -56,14 +56,14 @@ protected:
     /**
      * Get the vertex shader source.
      */
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderDefault;
     }
 
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return 0;
     }
 
@@ -81,13 +81,13 @@ protected:
      * Common initialization method for filters with vertex shader source <vShaderSrc>
      * fragment shader source <fShaderSrc> and render output orientation <o>.
      */
-    void filterInit(const char *vShaderSrc, const char *fShaderSrc, RenderOrientation o = RenderOrientationNone);
+    void filterInit(const char* vShaderSrc, const char* fShaderSrc, RenderOrientation o = RenderOrientationNone);
 
     /**
      * Common filter shader creation method with vertexshader source <vSaderSrc>
      * fragment shader source <fShaderSrc> and texture target <target>.
      */
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
 
     /**
      * Initialize texture coordinate buffer according to member variable
@@ -99,27 +99,26 @@ protected:
      * Return texture coordinates cooresponding to a particular orientation: buffer according to member variable
      * <renderOrientation> or override member variable by <overrideRenderOrientation>.
      */
-    static const GLfloat * getTexCoordBuf(RenderOrientation o);
+    static const GLfloat* getTexCoordBuf(RenderOrientation o);
 
     virtual void filterRenderPrepare();
     virtual void filterRenderSetCoords();
     virtual void filterRenderDraw();
     virtual void filterRenderCleanup();
 
-    static const char *vshaderFilter3x3Src; // GPUImage vertex shader (3x3 access)
-    static const char *vshaderGPUImage; // GPUImage vertex shader (shader compatibility)
-    static const char *vshaderDefault;  // default vertex shader to render a fullscreen quad
+    static const char* vshaderFilter3x3Src; // GPUImage vertex shader (3x3 access)
+    static const char* vshaderGPUImage; // GPUImage vertex shader (shader compatibility)
+    static const char* vshaderDefault; // default vertex shader to render a fullscreen quad
 
-    const char *vertexShaderSrcForCompilation = nullptr;  // used vertex shader source for shader compilation
-    const char *fragShaderSrcForCompilation = nullptr;	  // used fragment shader source for shader compilation
+    const char* vertexShaderSrcForCompilation = nullptr; // used vertex shader source for shader compilation
+    const char* fragShaderSrcForCompilation = nullptr; // used fragment shader source for shader compilation
 
-    GLint shParamAPos;          // shader attribute vertex positions
-    GLint shParamATexCoord;     // shader attribute texture coordinates
+    GLint shParamAPos; // shader attribute vertex positions
+    GLint shParamATexCoord; // shader attribute texture coordinates
 
     GLfloat vertexBuf[OGLES_GPGPU_QUAD_VERTEX_BUFSIZE]; // vertex data buffer for a quad
-    GLfloat texCoordBuf[OGLES_GPGPU_QUAD_TEX_BUFSIZE];  // texture coordinate data buffer for a quad
+    GLfloat texCoordBuf[OGLES_GPGPU_QUAD_TEX_BUFSIZE]; // texture coordinate data buffer for a quad
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/common/proc/base/multipassproc.cpp
+++ b/ogles_gpgpu/common/proc/base/multipassproc.cpp
@@ -17,7 +17,7 @@ ProcInterface* MultiPassProc::getInputFilter() const {
 ProcInterface* MultiPassProc::getOutputFilter() const {
     return procPasses.back();
 }
-ProcInterface * MultiPassProc::operator[](int i) const {
+ProcInterface* MultiPassProc::operator[](int i) const {
     return procPasses[i];
 }
 size_t MultiPassProc::size() const {
@@ -28,7 +28,7 @@ size_t MultiPassProc::size() const {
 
 MultiPassProc::~MultiPassProc() {
     // remove all pass instances
-    for(auto &it : procPasses) {
+    for (auto& it : procPasses) {
         delete it;
     }
 
@@ -38,11 +38,11 @@ MultiPassProc::~MultiPassProc() {
 #pragma mark ProcInterface methods
 
 int MultiPassProc::init(int inW, int inH, unsigned int order, bool prepareForExternalInput) {
-    ProcInterface *prevProc = NULL;
+    ProcInterface* prevProc = NULL;
     int num = 0;
     int numInitialized = 0;
 
-    for(auto &it : procPasses) {
+    for (auto& it : procPasses) {
 
         // find out the input frame size for the proc
         int pipelineFrameW, pipelineFrameH;
@@ -69,11 +69,11 @@ int MultiPassProc::init(int inW, int inH, unsigned int order, bool prepareForExt
 }
 
 int MultiPassProc::reinit(int inW, int inH, bool prepareForExternalInput) {
-    ProcInterface *prevProc = NULL;
+    ProcInterface* prevProc = NULL;
     int num = 0;
     int numInitialized = 0;
 
-    for(auto &it : procPasses) {
+    for (auto& it : procPasses) {
 
         // find out the input frame size for the proc
         int pipelineFrameW, pipelineFrameH;
@@ -100,35 +100,35 @@ int MultiPassProc::reinit(int inW, int inH, bool prepareForExternalInput) {
 }
 
 void MultiPassProc::cleanup() {
-    for(auto &it : procPasses) {
+    for (auto& it : procPasses) {
         it->cleanup();
     }
 }
 
 void MultiPassProc::createFBOTex(bool genMipmap) {
     bool first = true;
-    for(auto &it : procPasses) {
+    for (auto& it : procPasses) {
         it->createFBOTex(first ? genMipmap : false);
         first = false;
     }
 }
 
 int MultiPassProc::render(int position) {
-    for(auto &it : procPasses) {
+    for (auto& it : procPasses) {
         it->render(position);
     }
     return 0;
 }
 
 void MultiPassProc::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int position) {
-    ProcInterface *prevProc = NULL;
+    ProcInterface* prevProc = NULL;
 
     assert(position == 0); // for now no multi-texture multi-pass filters are supported
 
-    for(auto &it : procPasses) {
-        if (!prevProc) {    // means this is the first proc pass
+    for (auto& it : procPasses) {
+        if (!prevProc) { // means this is the first proc pass
             it->useTexture(id, useTexUnit, target);
-        } else {            // all other passes
+        } else { // all other passes
             it->useTexture(prevProc->getOutputTexId(), prevProc->getTextureUnit(), prevProc->getTextureTarget());
         }
         prevProc = it;
@@ -136,8 +136,8 @@ void MultiPassProc::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int 
 }
 
 bool MultiPassProc::getWillDownscale() const {
-    for (auto &it : procPasses) {
-        if(it->getWillDownscale()) {
+    for (auto& it : procPasses) {
+        if (it->getWillDownscale()) {
             return true;
         }
     }

--- a/ogles_gpgpu/common/proc/base/multipassproc.h
+++ b/ogles_gpgpu/common/proc/base/multipassproc.h
@@ -24,10 +24,9 @@ namespace ogles_gpgpu {
 
 class MultiPassProc : public MultiProcInterface {
 public:
-
     virtual ProcInterface* getInputFilter() const;
     virtual ProcInterface* getOutputFilter() const;
-    virtual ProcInterface * operator[](int i) const;
+    virtual ProcInterface* operator[](int i) const;
     virtual size_t size() const;
 
     /**
@@ -63,12 +62,12 @@ public:
      * Render a result, i.e. run the shader on the input texture.
      * Abstract method.
      */
-    virtual int render(int position=0);
+    virtual int render(int position = 0);
 
     /**
      * Use texture id <id> as input texture at texture <useTexUnit> with texture target <target>.
      */
-    virtual void useTexture(GLuint id, GLuint useTexUnit = 1, GLenum target = GL_TEXTURE_2D, int position=0);
+    virtual void useTexture(GLuint id, GLuint useTexUnit = 1, GLenum target = GL_TEXTURE_2D, int position = 0);
 
     /**
      * Returns true if output size < input size.
@@ -85,15 +84,13 @@ public:
     /**
      * Return te list of processor instances of each pass of this multipass processor.
      */
-    std::vector<ProcInterface *> getProcPasses() const {
+    std::vector<ProcInterface*> getProcPasses() const {
         return procPasses;
     }
 
 protected:
-
-    std::vector<ProcInterface *> procPasses;   // holds all instances to the single processing passes. strong ref!
+    std::vector<ProcInterface*> procPasses; // holds all instances to the single processing passes. strong ref!
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/common/proc/base/multiprocinterface.cpp
+++ b/ogles_gpgpu/common/proc/base/multiprocinterface.cpp
@@ -14,7 +14,7 @@ RenderOrientation MultiProcInterface::getOutputRenderOrientation() const {
 void MultiProcInterface::setExternalInputDataFormat(GLenum fmt) {
     return getInputFilter()->setExternalInputDataFormat(fmt);
 }
-void MultiProcInterface::setExternalInputData(const unsigned char *data) {
+void MultiProcInterface::setExternalInputData(const unsigned char* data) {
     return getInputFilter()->setExternalInputData(data);
 }
 GLuint MultiProcInterface::getTextureUnit() const {
@@ -41,16 +41,16 @@ int MultiProcInterface::getInFrameH() const {
 bool MultiProcInterface::getWillDownscale() const {
     return getInputFilter()->getWillDownscale();
 }
-void MultiProcInterface::getResultData(unsigned char *data) const {
+void MultiProcInterface::getResultData(unsigned char* data) const {
     getOutputFilter()->getResultData(data);
 }
-void MultiProcInterface::getResultData(FrameDelegate &delegate) const {
+void MultiProcInterface::getResultData(FrameDelegate& delegate) const {
     getOutputFilter()->getResultData(delegate);
 }
-MemTransfer *MultiProcInterface::getMemTransferObj() const {
+MemTransfer* MultiProcInterface::getMemTransferObj() const {
     return getOutputFilter()->getMemTransferObj();
 }
-MemTransfer *MultiProcInterface::getInputMemTransferObj() const {
+MemTransfer* MultiProcInterface::getInputMemTransferObj() const {
     return getInputFilter()->getMemTransferObj();
 }
 GLuint MultiProcInterface::getInputTexId() const {
@@ -61,7 +61,7 @@ GLuint MultiProcInterface::getOutputTexId() const {
 }
 void MultiProcInterface::printInfo() {
     OG_LOGINF(getProcName(), "begin info for %u passes", (unsigned int)size());
-    for(int i = 0; i < size(); i++) {
+    for (int i = 0; i < size(); i++) {
         (*this)[i]->printInfo();
     }
     OG_LOGINF(getProcName(), "end info");

--- a/ogles_gpgpu/common/proc/base/multiprocinterface.h
+++ b/ogles_gpgpu/common/proc/base/multiprocinterface.h
@@ -12,14 +12,13 @@ BEGIN_OGLES_GPGPU
 class MultiProcInterface : public ProcInterface {
 
 public:
-
     // ######## First/last filter access:
     MultiProcInterface() {}
     virtual ~MultiProcInterface() {}
 
     virtual ProcInterface* getInputFilter() const = 0;
     virtual ProcInterface* getOutputFilter() const = 0;
-    virtual ProcInterface * operator[](int i) const = 0;
+    virtual ProcInterface* operator[](int i) const = 0;
     virtual size_t size() const = 0;
     virtual void printInfo();
 
@@ -29,7 +28,7 @@ public:
     virtual RenderOrientation getOutputRenderOrientation() const;
 
     virtual void setExternalInputDataFormat(GLenum fmt);
-    virtual void setExternalInputData(const unsigned char *data);
+    virtual void setExternalInputData(const unsigned char* data);
     virtual GLuint getTextureUnit() const;
     virtual void setOutputSize(float scaleFactor);
     virtual void setOutputSize(int outW, int outH);
@@ -38,10 +37,10 @@ public:
     virtual int getInFrameW() const;
     virtual int getInFrameH() const;
     virtual bool getWillDownscale() const;
-    virtual void getResultData(unsigned char *data) const;
-    virtual void getResultData(FrameDelegate &delegate) const;
-    virtual MemTransfer *getMemTransferObj() const;
-    virtual MemTransfer *getInputMemTransferObj() const;
+    virtual void getResultData(unsigned char* data) const;
+    virtual void getResultData(FrameDelegate& delegate) const;
+    virtual MemTransfer* getMemTransferObj() const;
+    virtual MemTransfer* getInputMemTransferObj() const;
     virtual GLuint getInputTexId() const;
     virtual GLuint getOutputTexId() const;
 };
@@ -49,4 +48,3 @@ public:
 END_OGLES_GPGPU
 
 #endif
-

--- a/ogles_gpgpu/common/proc/base/procbase.cpp
+++ b/ogles_gpgpu/common/proc/base/procbase.cpp
@@ -63,14 +63,12 @@ const GLfloat ProcBase::quadTexCoordsDiagonalMirrored[] = {
     0, 1
 };
 
-
 const GLfloat ProcBase::quadVertices[] = {
     -1, -1, 0,
     1, -1, 0,
-    -1,  1, 0,
-    1,  1, 0
+    -1, 1, 0,
+    1, 1, 0
 };
-
 
 ProcBase::ProcBase() {
     texId = 0;
@@ -107,23 +105,23 @@ void ProcBase::printInfo() {
     assert(fbo);
 
     OG_LOGINF(getProcName(), "info: order num %d, input tex %d (%dx%d), output tex %d (%dx%d), downscale %d",
-              orderNum,
-              texId, inFrameW, inFrameH,
-              fbo->getAttachedTexId(), outFrameW, outFrameH,
-              willDownscale);
+        orderNum,
+        texId, inFrameW, inFrameH,
+        fbo->getAttachedTexId(), outFrameW, outFrameH,
+        willDownscale);
 }
 
-void ProcBase::getResultData(unsigned char *data) const {
+void ProcBase::getResultData(unsigned char* data) const {
     assert(fbo != NULL);
     fbo->readBuffer(data);
 }
 
-void ProcBase::getResultData(FrameDelegate &delegate) const {
+void ProcBase::getResultData(FrameDelegate& delegate) const {
     assert(fbo != NULL);
     fbo->readBuffer(delegate);
 }
 
-MemTransfer *ProcBase::getMemTransferObj() const {
+MemTransfer* ProcBase::getMemTransferObj() const {
     assert(fbo);
 
     return fbo->getMemTransfer();
@@ -150,14 +148,14 @@ int ProcBase::reinit(int inW, int inH, bool prepareForExternalInput) {
 
     setInOutFrameSizes(inW, inH, procParamOutW, procParamOutH, procParamOutScale);
 
-    fbo->destroyAttachedTex();  // needs to be recreated later!
+    fbo->destroyAttachedTex(); // needs to be recreated later!
 
-    if (prepareForExternalInput) {    // recreate input
+    if (prepareForExternalInput) { // recreate input
         useTexture(fbo->getMemTransfer()->prepareInput(inFrameW, inFrameH, inputDataFmt));
     }
 
     OG_LOGINF(getProcName(), "reinit with input size %dx%d, output size %dx%d, downscale %d",
-              inFrameW, inFrameH, outFrameW, outFrameH, willDownscale);
+        inFrameW, inFrameH, outFrameW, outFrameH, willDownscale);
 
     return 1;
 }
@@ -177,10 +175,10 @@ void ProcBase::baseInit(int inW, int inH, unsigned int order, bool prepareForExt
     }
 
     OG_LOGINF(getProcName(), "init with input size %dx%d, output size %dx%d, downscale %d",
-              inFrameW, inFrameH, outFrameW, outFrameH, willDownscale);
+        inFrameW, inFrameH, outFrameW, outFrameH, willDownscale);
 }
 
-void ProcBase::setExternalInputData(const unsigned char *data) {
+void ProcBase::setExternalInputData(const unsigned char* data) {
     fbo->getMemTransfer()->toGPU(data);
 }
 
@@ -191,8 +189,8 @@ void ProcBase::setInOutFrameSizes(int inW, int inH, int outW, int outH, float sc
     bool isFirst = (outW <= 0 && outH <= 0);
 
     // If only one dimension is specified, compute the other via aspect ratio:
-    if((std::min(outW, outH) <= 0) && (std::max(outW, outH) > 0)) {
-        if(outH > 0) {
+    if ((std::min(outW, outH) <= 0) && (std::max(outW, outH) > 0)) {
+        if (outH > 0) {
             outW = (outH * inW / inH);
         } else {
             outH = (outW * inH / inW);
@@ -209,7 +207,7 @@ void ProcBase::setInOutFrameSizes(int inW, int inH, int outW, int outH, float sc
     }
 
     // For transpose operatinos we need swap outW and outH
-    if(isFirst && (renderOrientation >= RenderOrientationDiagonal)) {
+    if (isFirst && (renderOrientation >= RenderOrientationDiagonal)) {
         std::swap(outW, outH);
     }
 
@@ -228,16 +226,18 @@ void ProcBase::createFBO() {
     fbo->setGLTexUnit(1);
 }
 
-void ProcBase::createShader(const char *vShSrc, const char *fShSrc, GLenum target, const Shader::Attributes &attributes) {
-    if (shader) {	// already compiled,
-        if (texTarget != target) delete shader;	 // change in texture target -> recreate!
-        else return;	// no change -> do nothing
+void ProcBase::createShader(const char* vShSrc, const char* fShSrc, GLenum target, const Shader::Attributes& attributes) {
+    if (shader) { // already compiled,
+        if (texTarget != target)
+            delete shader; // change in texture target -> recreate!
+        else
+            return; // no change -> do nothing
     }
 
     string fSrcStr(fShSrc);
 
 #ifdef GL_TEXTURE_EXTERNAL_OES
-    if (target == GL_TEXTURE_EXTERNAL_OES) {	// other texture target than default "GL_TEXTURE_2D"
+    if (target == GL_TEXTURE_EXTERNAL_OES) { // other texture target than default "GL_TEXTURE_2D"
         // we need to modify the fragment shader source for correct texture access
         string newSrcHeader = "#extension GL_OES_EGL_image_external : require\n";
         string newSrcReplacementOld = "uniform sampler2D ";

--- a/ogles_gpgpu/common/proc/base/procbase.h
+++ b/ogles_gpgpu/common/proc/base/procbase.h
@@ -17,14 +17,14 @@
 #include "procinterface.h"
 
 #include "../../gl/fbo.h"
-#include "../../gl/shader.h"
 #include "../../gl/memtransfer.h"
+#include "../../gl/shader.h"
 
-#define OGLES_GPGPU_QUAD_VERTICES 				4
-#define OGLES_GPGPU_QUAD_COORDS_PER_VERTEX      3
-#define OGLES_GPGPU_QUAD_TEXCOORDS_PER_VERTEX 	2
-#define OGLES_GPGPU_QUAD_VERTEX_BUFSIZE          (OGLES_GPGPU_QUAD_VERTICES * OGLES_GPGPU_QUAD_COORDS_PER_VERTEX)
-#define OGLES_GPGPU_QUAD_TEX_BUFSIZE 			(OGLES_GPGPU_QUAD_VERTICES * OGLES_GPGPU_QUAD_TEXCOORDS_PER_VERTEX)
+#define OGLES_GPGPU_QUAD_VERTICES 4
+#define OGLES_GPGPU_QUAD_COORDS_PER_VERTEX 3
+#define OGLES_GPGPU_QUAD_TEXCOORDS_PER_VERTEX 2
+#define OGLES_GPGPU_QUAD_VERTEX_BUFSIZE (OGLES_GPGPU_QUAD_VERTICES * OGLES_GPGPU_QUAD_COORDS_PER_VERTEX)
+#define OGLES_GPGPU_QUAD_TEX_BUFSIZE (OGLES_GPGPU_QUAD_VERTICES * OGLES_GPGPU_QUAD_TEXCOORDS_PER_VERTEX)
 
 namespace ogles_gpgpu {
 
@@ -67,7 +67,7 @@ public:
      * Insert external data into this processor. It will be used as input texture.
      * Note: init() must have been called with prepareForExternalInput = true for that.
      */
-    virtual void setExternalInputData(const unsigned char *data);
+    virtual void setExternalInputData(const unsigned char* data);
 
     /**
      * Create a texture that is attached to the FBO and will contain the processing result.
@@ -90,7 +90,7 @@ public:
     /**
      * Set output size by scaling down or up the input frame size by factor <scaleFactor>.
      */
-    virtual void setOutputSize(float scaleFactor)  {
+    virtual void setOutputSize(float scaleFactor) {
         procParamOutScale = scaleFactor;
     }
 
@@ -154,17 +154,17 @@ public:
     /**
      * Return the result data from the FBO.
      */
-    virtual void getResultData(unsigned char *data) const;
+    virtual void getResultData(unsigned char* data) const;
 
     /**
      * Return the result data from the FBO.
      */
-    virtual void getResultData(FrameDelegate &delegate) const;
+    virtual void getResultData(FrameDelegate& delegate) const;
 
     /**
      * Return pointer to MemTransfer object of this processor.
      */
-    virtual MemTransfer *getMemTransferObj() const;
+    virtual MemTransfer* getMemTransferObj() const;
 
     /**
      * Return input texture id.
@@ -209,47 +209,45 @@ protected:
      * <vshSrc> and <fshSrc>. The fragment shader source might be modified, depending
      * on texture target <target>.
      */
-    virtual void createShader(const char *vShSrc, const char *fShSrc, GLenum target, const Shader::Attributes &attributes= {});
+    virtual void createShader(const char* vShSrc, const char* fShSrc, GLenum target, const Shader::Attributes& attributes = {});
 
+    static const GLfloat quadTexCoordsStd[]; // default quad texture coordinates
+    static const GLfloat quadTexCoordsStdMirrored[]; // default quad texture coordinates (mirrored)
+    static const GLfloat quadTexCoordsFlipped[]; // flipped quad texture coordinates
+    static const GLfloat quadTexCoordsFlippedMirrored[]; // flipped, mirrored quad texture coordinates
+    static const GLfloat quadTexCoordsDiagonal[]; // diagonal quad texture coordinates
+    static const GLfloat quadTexCoordsDiagonalFlipped[]; // diagonal flipped quad texture coordinates
+    static const GLfloat quadTexCoordsDiagonalMirrored[]; // diagonal mirrored quad texture coordinates
+    static const GLfloat quadVertices[]; // default quad vertices
 
-    static const GLfloat quadTexCoordsStd[];                // default quad texture coordinates
-    static const GLfloat quadTexCoordsStdMirrored[];        // default quad texture coordinates (mirrored)
-    static const GLfloat quadTexCoordsFlipped[];            // flipped quad texture coordinates
-    static const GLfloat quadTexCoordsFlippedMirrored[];    // flipped, mirrored quad texture coordinates
-    static const GLfloat quadTexCoordsDiagonal[];           // diagonal quad texture coordinates
-    static const GLfloat quadTexCoordsDiagonalFlipped[];    // diagonal flipped quad texture coordinates
-    static const GLfloat quadTexCoordsDiagonalMirrored[];   // diagonal mirrored quad texture coordinates
-    static const GLfloat quadVertices[];                    // default quad vertices
+    FBO* fbo; // strong ref.!
+    Shader* shader; // strong ref.!
 
-    FBO *fbo;       // strong ref.!
-    Shader *shader;	// strong ref.!
-
-    unsigned int orderNum;  // position of this processor in the pipeline
+    unsigned int orderNum; // position of this processor in the pipeline
 
     bool hasTexId = true;
-    GLuint texId;       // input texture id
-    GLuint texUnit;     // input texture unit (glActiveTexture())
-    GLenum texTarget;   // input texture target
+    GLuint texId; // input texture id
+    GLuint texUnit; // input texture unit (glActiveTexture())
+    GLenum texTarget; // input texture target
 
-    GLint shParamUInputTex;     // shader uniform input texture sampler
+    GLint shParamUInputTex; // shader uniform input texture sampler
 
-    int procParamOutW;          // output frame width parameter
-    int procParamOutH;          // output frame height parameter
-    float procParamOutScale;    // output frame scaling parameter
+    int procParamOutW; // output frame width parameter
+    int procParamOutH; // output frame height parameter
+    float procParamOutScale; // output frame scaling parameter
 
-    RenderOrientation renderOrientation;    // output render orientation
+    RenderOrientation renderOrientation; // output render orientation
 
     bool willDownscale; // is true if output size < input size.
 
-    GLenum inputDataFmt;    // input pixel data format
+    GLenum inputDataFmt; // input pixel data format
 
-    int inFrameW = 0;   // input frame width
-    int inFrameH = 0;   // input frame height
+    int inFrameW = 0; // input frame width
+    int inFrameH = 0; // input frame height
 
-    int outFrameW = 0;  // output frame width
-    int outFrameH = 0;  // output frame height
+    int outFrameW = 0; // output frame width
+    int outFrameH = 0; // output frame height
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/common/proc/base/procinterface.h
+++ b/ogles_gpgpu/common/proc/base/procinterface.h
@@ -26,17 +26,16 @@ BEGIN_OGLES_GPGPU
  */
 class ProcInterface {
 public:
+    typedef std::function<void(const std::string& tag)> Logger;
 
-    typedef std::function<void(const std::string &tag)> Logger;
-
-    using ProcDelegate = std::function<void(ProcInterface *)>;
+    using ProcDelegate = std::function<void(ProcInterface*)>;
 
     using FrameDelegate = MemTransfer::FrameDelegate;
 
     /**
      * Important: deconstructor must be virtual
      */
-    virtual ~ProcInterface() { }
+    virtual ~ProcInterface() {}
 
     /**
      * Init the processor for input frames of size <inW>x<inH> which is at
@@ -64,7 +63,7 @@ public:
      * Insert external data into this processor. It will be used as input texture.
      * Note: init() must have been called with prepareForExternalInput = true for that.
      */
-    virtual void setExternalInputData(const unsigned char *data) = 0;
+    virtual void setExternalInputData(const unsigned char* data) = 0;
 
     /**
      * Create a texture that is attached to the FBO and will contain the processing result.
@@ -76,24 +75,24 @@ public:
      * Render a result, i.e. run the shader on the input texture.
      * Abstract method.  Return 0 on success.
      */
-    virtual int render(int position=0) = 0;
+    virtual int render(int position = 0) = 0;
 
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() = 0;
+    virtual const char* getProcName() = 0;
 
     /**
      * Set a custom tag name.
      */
-    virtual void setProcTitle(const std::string &name) {
+    virtual void setProcTitle(const std::string& name) {
         title = name;
     }
 
     /**
      * Return the custom tag name.
      */
-    virtual const char *getProcTitle() {
+    virtual const char* getProcTitle() {
         return title.c_str();
     }
 
@@ -105,7 +104,7 @@ public:
     /**
      * Use texture id <id> as input texture at texture <useTexUnit> with texture target <target>.
      */
-    virtual void useTexture(GLuint id, GLuint useTexUnit = 1, GLenum target = GL_TEXTURE_2D, int position=0) = 0;
+    virtual void useTexture(GLuint id, GLuint useTexUnit = 1, GLenum target = GL_TEXTURE_2D, int position = 0) = 0;
 
     /**
      * Return used texture unit.
@@ -181,24 +180,24 @@ public:
     /**
      * Return the result data from the FBO.
      */
-    virtual void getResultData(unsigned char *data) const = 0;
+    virtual void getResultData(unsigned char* data) const = 0;
 
     /**
      * Return the result data from the FBO (zero copy).
      */
-    virtual void getResultData(FrameDelegate &) const = 0;
+    virtual void getResultData(FrameDelegate&) const = 0;
 
     /**
      * Return pointer to MemTransfer object of this processor.
      */
-    virtual MemTransfer *getMemTransferObj() const = 0;
+    virtual MemTransfer* getMemTransferObj() const = 0;
 
     /**
      * Return pointer to designated input MemTransfer object of this processor.
      *
      * Note: This is typically the same, except for multi-pass processors.
      */
-    virtual MemTransfer *getInputMemTransferObj() const {
+    virtual MemTransfer* getInputMemTransferObj() const {
         return getMemTransferObj();
     }
 
@@ -217,7 +216,7 @@ public:
     /**
      * Add a subscriber
      */
-    virtual void add(ProcInterface *filter, int position=0);
+    virtual void add(ProcInterface* filter, int position = 0);
 
     /**
      * Prepare the filter chain
@@ -254,36 +253,34 @@ public:
     /**
      * Set a pre processing callback
      */
-    virtual void setPreProcessCallback(ProcDelegate &cb);
+    virtual void setPreProcessCallback(ProcDelegate& cb);
 
     /**
      * Set a pre processing callback
      */
-    virtual void setPostProcessCallback(ProcDelegate &cb);
+    virtual void setPostProcessCallback(ProcDelegate& cb);
 
     /**
      * Set a pre render callback
      */
-    virtual void setPreRenderCallback(ProcDelegate &cb);
+    virtual void setPreRenderCallback(ProcDelegate& cb);
 
     /**
      * Set a post render callback
      */
-    virtual void setPostRenderCallback(ProcDelegate &cb);
+    virtual void setPostRenderCallback(ProcDelegate& cb);
 
     /**
      * Set a pre init callback
      */
-    virtual void setPreInitCallback(ProcDelegate &cb);
+    virtual void setPreInitCallback(ProcDelegate& cb);
 
     /**
      * Set a post init callback
      */
-    virtual void setPostInitCallback(ProcDelegate &cb);
-
+    virtual void setPostInitCallback(ProcDelegate& cb);
 
 protected:
-
     /**
      * Get a formatted/unique filter tag
      */
@@ -295,7 +292,7 @@ protected:
 
     bool active = true;
 
-    std::vector<std::pair<ProcInterface *, int>> subscribers;
+    std::vector<std::pair<ProcInterface*, int>> subscribers;
 
     ProcDelegate m_preProcessCallback;
     ProcDelegate m_postProcessCallback;

--- a/ogles_gpgpu/common/proc/blend.cpp
+++ b/ogles_gpgpu/common/proc/blend.cpp
@@ -6,18 +6,17 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "blend.h"
+#include "../common_includes.h"
 
 using namespace ogles_gpgpu;
 
-// *INDENT-OFF*
-const char *BlendProc::fshaderBlendSrc = OG_TO_STR
-(
+// clang-format off
+const char *BlendProc::fshaderBlendSrc =
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  varying vec2 textureCoordinate2;
 
@@ -31,10 +30,10 @@ const char *BlendProc::fshaderBlendSrc = OG_TO_STR
     vec4 textureColor2 = texture2D(inputImageTexture2, textureCoordinate);
     gl_FragColor = mix(textureColor, textureColor2, alpha);
  });
-// *INDENT-ON*
+// clang-format on
 
-BlendProc::BlendProc(float alpha) : alpha(alpha) {
-
+BlendProc::BlendProc(float alpha)
+    : alpha(alpha) {
 }
 
 void BlendProc::getUniforms() {

--- a/ogles_gpgpu/common/proc/blend.h
+++ b/ogles_gpgpu/common/proc/blend.h
@@ -17,7 +17,7 @@ BEGIN_OGLES_GPGPU
 class BlendProc : public TwoInputProc {
 public:
     BlendProc(float alpha = 1.0f);
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "BlendProc";
     }
     virtual void getUniforms();
@@ -28,14 +28,13 @@ public:
     virtual int render(int position = 0);
 
 private:
-
     GLint shParamUAlpha;
     GLfloat alpha = 0.5f;
 
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderBlendSrc;
     }
-    static const char *fshaderBlendSrc;   // fragment shader source
+    static const char* fshaderBlendSrc; // fragment shader source
 };
 
 END_OGLES_GPGPU

--- a/ogles_gpgpu/common/proc/box_opt.h
+++ b/ogles_gpgpu/common/proc/box_opt.h
@@ -18,8 +18,8 @@ namespace ogles_gpgpu {
 class BoxOptProc : public MultiPassProc {
 public:
     BoxOptProc(float blurRadius = 5.0) {
-        BoxOptProcPass *boxPass1 = new BoxOptProcPass(1, blurRadius);
-        BoxOptProcPass *boxPass2 = new BoxOptProcPass(2, blurRadius);
+        BoxOptProcPass* boxPass1 = new BoxOptProcPass(1, blurRadius);
+        BoxOptProcPass* boxPass2 = new BoxOptProcPass(2, blurRadius);
 
         procPasses.push_back(boxPass1);
         procPasses.push_back(boxPass2);
@@ -28,7 +28,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "BoxOptProc";
     }
 };

--- a/ogles_gpgpu/common/proc/diff.cpp
+++ b/ogles_gpgpu/common/proc/diff.cpp
@@ -6,17 +6,17 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "diff.h"
+#include "../common_includes.h"
 
 using namespace ogles_gpgpu;
 
-// *INDENT-OFF*
-const char *DiffProc::fshaderDiffSrc = OG_TO_STR
-(
+// clang-format off
+const char *DiffProc::fshaderDiffSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
+OG_TO_STR(    
  varying vec2 textureCoordinate;
  uniform sampler2D inputImageTexture;
  uniform sampler2D inputImageTexture2;
@@ -27,12 +27,13 @@ const char *DiffProc::fshaderDiffSrc = OG_TO_STR
      vec4 centerIntensity = texture2D(inputImageTexture, textureCoordinate);
      vec4 centerIntensity2 = texture2D(inputImageTexture2, textureCoordinate);
      vec3 dt = (centerIntensity.rgb-centerIntensity2.rgb) * strength;
-     gl_FragColor = vec4(vec3(clamp(dt, 0.0, 1.0)), 1.0);
+     gl_FragColor = vec4(vec3(clamp(dt + offset, 0.0, 1.0)), 1.0);
  });
-// *INDENT-ON*
+// clang-format on
 
-DiffProc::DiffProc(float strength, float offset) : strength(strength), offset(offset) {
-
+DiffProc::DiffProc(float strength, float offset)
+    : strength(strength)
+    , offset(offset) {
 }
 
 void DiffProc::getUniforms() {

--- a/ogles_gpgpu/common/proc/diff.h
+++ b/ogles_gpgpu/common/proc/diff.h
@@ -18,9 +18,9 @@ namespace ogles_gpgpu {
 
 class DiffProc : public TwoInputProc {
 public:
-    DiffProc(float strength = 1.f, float offset=0.f);
+    DiffProc(float strength = 1.f, float offset = 0.f);
     ~DiffProc() {}
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "DiffProc";
     }
     virtual void getUniforms();
@@ -32,18 +32,19 @@ public:
         offset = value;
     }
     virtual int render(int position = 0);
+
 private:
     GLuint shParamUStrength;
     GLuint shParamUOffset;
     float strength;
     float offset;
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderGPUImage;
     }
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderDiffSrc;
     }
-    static const char *fshaderDiffSrc;   // fragment shader source (diff)
+    static const char* fshaderDiffSrc; // fragment shader source (diff)
 };
 }
 

--- a/ogles_gpgpu/common/proc/disp.cpp
+++ b/ogles_gpgpu/common/proc/disp.cpp
@@ -7,19 +7,18 @@
 // See LICENSE file in project repository root for the license.
 //
 
-#include "../common_includes.h"
 #include "disp.h"
+#include "../common_includes.h"
 
 using namespace std;
 using namespace ogles_gpgpu;
 
-// *INDENT-OFF*
-const char *Disp::fshaderDispSrc = OG_TO_STR(
-
+// clang-format off
+const char *Disp::fshaderDispSrc =
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
 varying vec2 vTexCoord;
 uniform sampler2D uInputTex;
 void main()
@@ -27,7 +26,7 @@ void main()
     gl_FragColor = vec4(texture2D(uInputTex, vTexCoord).rgba);
 }
 );
-// *INDENT-ON*
+// clang-format on
 
 int Disp::init(int inW, int inH, unsigned int order, bool prepareForExternalInput) {
     OG_LOGINF(getProcName(), "initialize");
@@ -45,7 +44,7 @@ int Disp::render(int position) {
     OG_LOGINF(getProcName(), "input tex %d, target %d, framebuffer of size %dx%d", texId, texTarget, outFrameW, outFrameH);
 
     filterRenderPrepare();
-    glViewport(0, 0, outFrameW*resolutionX, outFrameH*resolutionY); // override
+    glViewport(tx, ty, outFrameW * resolutionX, outFrameH * resolutionY); // override
     Tools::checkGLErr(getProcName(), "render prepare");
 
     filterRenderSetCoords();

--- a/ogles_gpgpu/common/proc/disp.h
+++ b/ogles_gpgpu/common/proc/disp.h
@@ -25,7 +25,6 @@ namespace ogles_gpgpu {
  */
 class Disp : public FilterProcBase {
 public:
-
     /**
      * Output resolution of display.
      *
@@ -38,9 +37,20 @@ public:
     }
 
     /**
+     * Output display offset.
+     *
+     * This is useful for a "letterbox" display for fixed aspect ratio images on a resized
+     * canvas.
+     */
+    virtual void setOffset(float x, float y) {
+        tx = x;
+        ty = y;
+    }    
+
+    /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "Disp";
     }
 
@@ -65,33 +75,34 @@ public:
     /**
      * Not implemented - no output is returned because Disp renders on screen.
      */
-    virtual void getResultData(unsigned char *data) const {
+    virtual void getResultData(unsigned char* data) const {
         assert(false);
     }
 
     /**
      * Not implemented - no output is returned because Disp renders on screen.
      */
-    virtual void getResultData(FrameDelegate &frameDelegate) const {
+    virtual void getResultData(FrameDelegate& frameDelegate) const {
         assert(false);
     }
 
     /**
      * Not implemented - no MemTransferObj for output is set because Disp renders on screen.
      */
-    virtual MemTransfer *getMemTransferObj() const {
+    virtual MemTransfer* getMemTransferObj() const {
         assert(false);
         return NULL;
     }
 
 private:
 
+    float tx = 0.f;
+    float ty = 0.f;
     float resolutionX = 1.f;
     float resolutionY = 1.f;
 
-    static const char *fshaderDispSrc;         // fragment shader source
+    static const char* fshaderDispSrc; // fragment shader source
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/common/proc/fifo.h
+++ b/ogles_gpgpu/common/proc/fifo.h
@@ -6,7 +6,6 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-
 #ifndef OGLES_GPGPU_COMMON_PROC_FIFO
 #define OGLES_GPGPU_COMMON_PROC_FIFO
 
@@ -18,14 +17,13 @@ BEGIN_OGLES_GPGPU
 
 class FifoProc : public MultiProcInterface {
 public:
-
-    FifoProc(int size=2);
+    FifoProc(int size = 2);
 
     virtual ~FifoProc();
     virtual int init(int inW, int inH, unsigned int order, bool prepareForExternalInput = false);
     virtual int reinit(int inW, int inH, bool prepareForExternalInput = false);
     virtual void cleanup();
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "FifoProc";
     }
     virtual void createFBOTex(bool genMipmap);
@@ -42,7 +40,7 @@ public:
 
     virtual ProcInterface* getInputFilter() const;
     virtual ProcInterface* getOutputFilter() const;
-    virtual ProcInterface * operator[](int i) const;
+    virtual ProcInterface* operator[](int i) const;
     virtual size_t size() const {
         return procPasses.size();
     }
@@ -50,15 +48,15 @@ public:
     virtual int getIn() const;
     virtual int getOut() const;
 
-    virtual void addWithDelay(ProcInterface *filter, int position = 0, int time = 0);
+    virtual void addWithDelay(ProcInterface* filter, int position = 0, int time = 0);
 
     /**
      * Return te list of processor instances of each pass of this multipass processor.
      */
-    std::vector<ProcInterface *>& getProcPasses() {
+    std::vector<ProcInterface*>& getProcPasses() {
         return procPasses;
     }
-    const std::vector<ProcInterface *>& getProcPasses() const {
+    const std::vector<ProcInterface*>& getProcPasses() const {
         return procPasses;
     }
     bool isFull() const {
@@ -69,7 +67,6 @@ public:
     }
 
 protected:
-
     virtual void prepare(int inW, int inH, int index = 0, int position = 0);
     virtual void process(int position, Logger logger = {});
 
@@ -77,10 +74,10 @@ protected:
     int m_inputIndex = -1;
     int m_outputIndex = -1;
 
-    using FilterTarget = std::pair<ProcInterface *, int>;
+    using FilterTarget = std::pair<ProcInterface*, int>;
     std::vector<std::vector<FilterTarget>> delayedSubscribers;
 
-    std::vector<ProcInterface *> procPasses;   // holds all instances to the single processing passes. strong ref!
+    std::vector<ProcInterface*> procPasses; // holds all instances to the single processing passes. strong ref!
 };
 
 typedef FifoProc FIFOPRoc;

--- a/ogles_gpgpu/common/proc/filter3x3.cpp
+++ b/ogles_gpgpu/common/proc/filter3x3.cpp
@@ -6,17 +6,16 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "filter3x3.h"
+#include "../common_includes.h"
 
 using namespace std;
 using namespace ogles_gpgpu;
 
 Filter3x3Proc::Filter3x3Proc() {
-
 }
 
-void Filter3x3Proc::filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target) {
+void Filter3x3Proc::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target) {
     // create shader object
     ProcBase::createShader(vShaderSrc, fShaderSrc, target);
 
@@ -30,11 +29,10 @@ void Filter3x3Proc::filterShaderSetup(const char *vShaderSrc, const char *fShade
 }
 
 void Filter3x3Proc::getUniforms() {
-
 }
 
 void Filter3x3Proc::setUniforms() {
     // Set texel width/height uniforms:
-    glUniform1f(texelWidthUniform, (1.0f/ float(outFrameW)));
-    glUniform1f(texelHeightUniform, (1.0f/ float(outFrameH)));
+    glUniform1f(texelWidthUniform, (1.0f / float(outFrameW)));
+    glUniform1f(texelHeightUniform, (1.0f / float(outFrameH)));
 }

--- a/ogles_gpgpu/common/proc/filter3x3.h
+++ b/ogles_gpgpu/common/proc/filter3x3.h
@@ -20,7 +20,6 @@ namespace ogles_gpgpu {
  */
 class Filter3x3Proc : public FilterProcBase {
 public:
-
     /**
      * Constructor.
      */
@@ -29,14 +28,14 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "Filter3x3Proc";
     }
 
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderFilter3x3Src;
     }
 
@@ -53,7 +52,7 @@ public:
     /**
      * Setup the shaders
      */
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
 
     void setTexelWidth(float width) {
         hasOverriddenImageSizeFactor = true;
@@ -70,12 +69,11 @@ public:
     }
 
 protected:
-
     bool hasOverriddenImageSizeFactor = false;
     GLint texelWidthUniform, texelHeightUniform;
     float texelWidth, texelHeight;
 
-    static const char *fshaderFilter3x3Src;   // fragment shader source
+    static const char* fshaderFilter3x3Src; // fragment shader source
 };
 }
 

--- a/ogles_gpgpu/common/proc/fir3.cpp
+++ b/ogles_gpgpu/common/proc/fir3.cpp
@@ -6,18 +6,17 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "fir3.h"
+#include "../common_includes.h"
 
 using namespace ogles_gpgpu;
 
-// *INDENT-OFF*
-const char *Fir3Proc::fshaderFir3Src = OG_TO_STR
-(
+// clang-format off
+const char *Fir3Proc::fshaderFir3Src =
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
 
  uniform sampler2D inputImageTexture;
@@ -37,12 +36,11 @@ const char *Fir3Proc::fshaderFir3Src = OG_TO_STR
      gl_FragColor = vec4(response * alpha + beta, 1.0);
  });
 
-const char *Fir3Proc::fshaderFir3RGBSrc = OG_TO_STR
-(
+const char *Fir3Proc::fshaderFir3RGBSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
 
  uniform sampler2D inputImageTexture;
@@ -64,7 +62,7 @@ const char *Fir3Proc::fshaderFir3RGBSrc = OG_TO_STR
 
      gl_FragColor = vec4(response * alpha + beta, 1.0);
 });
-// *INDENT-ON*
+// clang-format on
 
 Fir3Proc::Fir3Proc(bool doRgb)
     : doRgb(doRgb) {
@@ -79,7 +77,7 @@ Fir3Proc::Fir3Proc(bool doRgb)
 void Fir3Proc::getUniforms() {
     ThreeInputProc::getUniforms();
 
-    if(doRgb) {
+    if (doRgb) {
         shParamUWeights1 = shader->getParam(UNIF, "weights1");
         shParamUWeights2 = shader->getParam(UNIF, "weights2");
         shParamUWeights3 = shader->getParam(UNIF, "weights3");
@@ -93,7 +91,7 @@ void Fir3Proc::getUniforms() {
 
 void Fir3Proc::setUniforms() {
     ThreeInputProc::setUniforms();
-    if(doRgb) {
+    if (doRgb) {
         glUniform3fv(shParamUWeights1, 1, &weightsRGB[0].data[0]);
         glUniform3fv(shParamUWeights2, 1, &weightsRGB[1].data[0]);
         glUniform3fv(shParamUWeights3, 1, &weightsRGB[2].data[0]);

--- a/ogles_gpgpu/common/proc/fir3.h
+++ b/ogles_gpgpu/common/proc/fir3.h
@@ -17,23 +17,23 @@ BEGIN_OGLES_GPGPU
 class Fir3Proc : public ThreeInputProc {
 public:
     Fir3Proc(bool doRgb = false);
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "Fir3Proc";
     }
     virtual void getUniforms();
     virtual void setUniforms();
 
-    virtual void setWeights(const Vec3f &value) {
+    virtual void setWeights(const Vec3f& value) {
         weights = value;
     }
 
-    virtual void setWeights(const Vec3f &f1, const Vec3f &f2, const Vec3f &f3) {
+    virtual void setWeights(const Vec3f& f1, const Vec3f& f2, const Vec3f& f3) {
         weightsRGB[0] = f1;
         weightsRGB[1] = f2;
         weightsRGB[2] = f3;
     }
 
-    virtual const Vec3f & getWeights() const {
+    virtual const Vec3f& getWeights() const {
         return weights;
     }
 
@@ -54,7 +54,6 @@ public:
     }
 
 private:
-
     bool doRgb = false;
 
     GLint shParamUWeights;
@@ -70,11 +69,11 @@ private:
     GLint shParamUWeights3;
     Vec3f weightsRGB[3];
 
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return doRgb ? fshaderFir3RGBSrc : fshaderFir3Src;
     }
-    static const char *fshaderFir3Src;      // fragment shader source
-    static const char *fshaderFir3RGBSrc;   // fragment shader source RGB
+    static const char* fshaderFir3Src; // fragment shader source
+    static const char* fshaderFir3RGBSrc; // fragment shader source RGB
 };
 
 END_OGLES_GPGPU

--- a/ogles_gpgpu/common/proc/flow.h
+++ b/ogles_gpgpu/common/proc/flow.h
@@ -23,11 +23,11 @@ BEGIN_OGLES_GPGPU
 
 class FlowProc : public FilterProcBase {
 public:
-    FlowProc(float tau=0.004, float strength = 1.0f);
-    virtual const char *getProcName() {
+    FlowProc(float tau = 0.004, float strength = 1.0f);
+    virtual const char* getProcName() {
         return "FlowProc";
     }
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
     virtual void getUniforms();
     virtual void setUniforms();
 
@@ -39,11 +39,10 @@ public:
     }
 
 private:
-
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderFlowSrc;
     }
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderGPUImage;
     }
 
@@ -59,16 +58,15 @@ private:
     std::string vshaderFlowDynamic;
     std::string fshaderFlowDynamic;
 
-    static const char *fshaderFlowSrc;     // fragment shader source
-    static const char *fshaderFlowSrcOpt;  // fragment shader source
+    static const char* fshaderFlowSrc; // fragment shader source
+    static const char* fshaderFlowSrcOpt; // fragment shader source
 };
-
 
 // Explicit access of first and last filter saves a whole bunch of boilerplate virtual API stuff:
 // TODO: may make this more like a multipass filter in the future
 class FlowPipeline : public MultiPassProc {
 public:
-    FlowPipeline(float tau = 0.004f, float strength = 1.0f, bool doGray=false);
+    FlowPipeline(float tau = 0.004f, float strength = 1.0f, bool doGray = false);
     virtual ~FlowPipeline();
     virtual float getStrength() const;
 
@@ -85,12 +83,11 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "FlowPipeline";
     }
 
 protected:
-
     struct Impl;
     std::unique_ptr<Impl> m_pImpl;
 };
@@ -103,9 +100,8 @@ protected:
 
 class FlowImplProc : public FilterProcBase {
 public:
-
     FlowImplProc(bool isX, float strength = 1.0f);
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "FlowImplProc";
     }
     virtual void getUniforms();
@@ -113,29 +109,30 @@ public:
     virtual void setStrength(float value) {
         strength = value;
     }
+
 private:
-    void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
 
     bool isX = false;
     GLint shParamUStrength;
     float strength = 1.f;
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderGPUImage;
     }
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return isX ? fshaderFlowXSrc : fshaderFlowYSrc;
     }
-    static const char *fshaderFlowXSrc;
-    static const char *fshaderFlowYSrc;
+    static const char* fshaderFlowXSrc;
+    static const char* fshaderFlowYSrc;
 };
 
 class Flow2Proc : public TwoInputProc {
 public:
-    Flow2Proc(float tau=0.004, float strength = 1.0f);
-    virtual const char *getProcName() {
+    Flow2Proc(float tau = 0.004, float strength = 1.0f);
+    virtual const char* getProcName() {
         return "Flow2Proc";
     }
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
     virtual void getUniforms();
     virtual void setUniforms();
 
@@ -147,11 +144,10 @@ public:
     }
 
 private:
-
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderFlowSrc;
     }
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderGPUImage;
     }
 
@@ -161,17 +157,16 @@ private:
     GLint shParamUStrength;
     GLfloat strength = 1.0f;
 
-    static const char *fshaderFlowSrc;     // fragment shader source
+    static const char* fshaderFlowSrc; // fragment shader source
 };
 
 class Flow2Pipeline : public MultiPassProc {
 public:
-
-    Flow2Pipeline(float tau = 0.004f, float strength = 1.0f, bool doGray=false);
+    Flow2Pipeline(float tau = 0.004f, float strength = 1.0f, bool doGray = false);
     ~Flow2Pipeline();
 
     virtual float getStrength() const;
-    virtual ProcInterface * corners(); // corner output
+    virtual ProcInterface* corners(); // corner output
 
     virtual ProcInterface* getInputFilter() const;
     virtual ProcInterface* getOutputFilter() const;
@@ -179,7 +174,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "Flow2Pipeline";
     }
 
@@ -188,7 +183,6 @@ public:
     virtual int render(int position);
 
 protected:
-
     struct Impl;
     std::unique_ptr<Impl> m_pImpl;
 };

--- a/ogles_gpgpu/common/proc/gain.cpp
+++ b/ogles_gpgpu/common/proc/gain.cpp
@@ -8,13 +8,13 @@
 
 #include "gain.h"
 
-// *INDENT-OFF*
+// clang-format off
 BEGIN_OGLES_GPGPU
-const char * GainProc::fshaderGainSrc = OG_TO_STR
-(
+const char * GainProc::fshaderGainSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
+OG_TO_STR(
  varying vec2 vTexCoord;
  uniform sampler2D uInputTex;
  uniform float gain;
@@ -23,5 +23,14 @@ const char * GainProc::fshaderGainSrc = OG_TO_STR
      vec4 val = texture2D(uInputTex, vTexCoord);
      gl_FragColor = clamp(val * gain, 0.0, 1.0);
  });
+
+void GainProc::getUniforms() {
+    shParamUGain = shader->getParam(UNIF, "gain");
+}
+
+void GainProc::setUniforms() {
+    glUniform1f(shParamUGain, gain);
+}
+
 END_OGLES_GPGPU
-// *INDENT-ON*
+// clang-format on

--- a/ogles_gpgpu/common/proc/gain.h
+++ b/ogles_gpgpu/common/proc/gain.h
@@ -21,51 +21,44 @@ public:
     /**
      * Constructor.
      */
-    GainProc(float gain=1.f) : gain(gain) {}
+    GainProc(float gain = 1.f)
+        : gain(gain) {
+    }
 
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "GainProc";
     }
 
     /**
      * Set the gain coefficient.
      */
-    void setGain(float value) {
-        gain = value;
-    }
+    void setGain(float value);
 
 private:
-
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderGainSrc;
     }
 
     /**
      * Get shader uniform id.
      */
-    virtual void getUniforms() {
-        shParamUGain = shader->getParam(UNIF, "gain");
-    }
+    virtual void getUniforms();
 
     /**
      * Set shader uniform values.
      */
-    virtual void setUniforms() {
-        glUniform1f(shParamUGain, gain);
-    }
+    virtual void setUniforms();
 
-    static const char *fshaderGainSrc; // fragment shader source
+    static const char* fshaderGainSrc; // fragment shader source
     float gain = 1.f;
     GLint shParamUGain;
 };
-
 }
 
 #endif
-

--- a/ogles_gpgpu/common/proc/gauss.h
+++ b/ogles_gpgpu/common/proc/gauss.h
@@ -23,9 +23,9 @@
 namespace ogles_gpgpu {
 class GaussProc : public MultiPassProc {
 public:
-    GaussProc(GaussProcPass::KernelSize kernel=GaussProcPass::k5Tap, bool doR=false) {
-        GaussProcPass *gaussPass1 = new GaussProcPass(1, kernel, doR);
-        GaussProcPass *gaussPass2 = new GaussProcPass(2, kernel, doR);
+    GaussProc(GaussProcPass::KernelSize kernel = GaussProcPass::k5Tap, bool doR = false) {
+        GaussProcPass* gaussPass1 = new GaussProcPass(1, kernel, doR);
+        GaussProcPass* gaussPass2 = new GaussProcPass(2, kernel, doR);
 
         procPasses.push_back(gaussPass1);
         procPasses.push_back(gaussPass2);
@@ -34,7 +34,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "GaussProc";
     }
 };

--- a/ogles_gpgpu/common/proc/gauss_opt.h
+++ b/ogles_gpgpu/common/proc/gauss_opt.h
@@ -20,9 +20,9 @@
 namespace ogles_gpgpu {
 class GaussOptProc : public MultiPassProc {
 public:
-    GaussOptProc(float blurRadius = 5.0, bool doNorm=false, float normConst=0.005f) {
-        GaussOptProcPass *gaussPass1 = new GaussOptProcPass(1, blurRadius, doNorm);
-        GaussOptProcPass *gaussPass2 = new GaussOptProcPass(2, blurRadius, doNorm, normConst);
+    GaussOptProc(float blurRadius = 5.0, bool doNorm = false, float normConst = 0.005f) {
+        GaussOptProcPass* gaussPass1 = new GaussOptProcPass(1, blurRadius, doNorm);
+        GaussOptProcPass* gaussPass2 = new GaussOptProcPass(2, blurRadius, doNorm, normConst);
 
         procPasses.push_back(gaussPass1);
         procPasses.push_back(gaussPass2);
@@ -31,7 +31,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "GaussOptProc";
     }
 };

--- a/ogles_gpgpu/common/proc/grad.cpp
+++ b/ogles_gpgpu/common/proc/grad.cpp
@@ -6,19 +6,18 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "grad.h"
+#include "../common_includes.h"
 
 using namespace std;
 using namespace ogles_gpgpu;
 
-// *INDENT-OFF*
-const char *GradProc::fshaderGradSrc = OG_TO_STR
-(
+// clang-format off
+const char *GradProc::fshaderGradSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  varying vec2 leftTextureCoordinate;
  varying vec2 rightTextureCoordinate;
@@ -70,17 +69,17 @@ precision highp float;
      gl_FragColor = vec4(mag, clamp(theta/pi, 0.0, 1.0), clamp(dx, 0.0, 1.0), clamp(dy, 0.0, 1.0));
  }
  );
-// *INDENT-ON*
+// clang-format on
 
-GradProc::GradProc(float strength) : strength(strength) {
-
+GradProc::GradProc(float strength)
+    : strength(strength) {
 }
 
 void GradProc::setUniforms() {
     Filter3x3Proc::setUniforms();
 
-    glUniform1f(texelWidthUniform, (1.0f/ float(outFrameW)));
-    glUniform1f(texelHeightUniform, (1.0f/ float(outFrameH)));
+    glUniform1f(texelWidthUniform, (1.0f / float(outFrameW)));
+    glUniform1f(texelHeightUniform, (1.0f / float(outFrameH)));
 
     glUniform1f(shParamUStrength, strength);
 }

--- a/ogles_gpgpu/common/proc/grad.h
+++ b/ogles_gpgpu/common/proc/grad.h
@@ -21,21 +21,20 @@ public:
     /**
      * Constructor.
      */
-    GradProc(float strength=1.f);
+    GradProc(float strength = 1.f);
 
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "GradProc";
     }
 
 private:
-
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderGradSrc;
     }
 
@@ -49,7 +48,7 @@ private:
      */
     virtual void setUniforms();
 
-    static const char *fshaderGradSrc;   // fragment shader source
+    static const char* fshaderGradSrc; // fragment shader source
 
     GLint shParamUStrength;
 

--- a/ogles_gpgpu/common/proc/grayscale.cpp
+++ b/ogles_gpgpu/common/proc/grayscale.cpp
@@ -9,8 +9,8 @@
 
 // Modifications: Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "grayscale.h"
+#include "../common_includes.h"
 
 #include <memory.h>
 
@@ -29,13 +29,14 @@ const GLfloat GrayscaleProc::grayscaleConvVecNone[3] = {
     1.0, 1.0, 1.0
 };
 
-// *INDENT-OFF*
-const char *GrayscaleProc::fshaderGrayscaleSrc = OG_TO_STR(
+// clang-format off
+const char *GrayscaleProc::fshaderGrayscaleSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
 
+OG_TO_STR(
 uniform sampler2D uInputTex;
 uniform vec3 uInputConvVec;
 varying vec2 vTexCoord;
@@ -46,15 +47,16 @@ void main()
     gl_FragColor = vec4(gray, gray, gray, 1.0);
 }
 );
-// *INDENT-ON*
+// clang-format on
 
-// *INDENT-OFF*
-const char *GrayscaleProc::fshaderNoopSrc = OG_TO_STR(
+// clang-format off
+const char *GrayscaleProc::fshaderNoopSrc =
 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
 
+OG_TO_STR(
  varying vec2 vTexCoord;
  uniform sampler2D uInputTex;
  void main()
@@ -62,7 +64,7 @@ const char *GrayscaleProc::fshaderNoopSrc = OG_TO_STR(
      gl_FragColor = vec4(texture2D(uInputTex, vTexCoord).rgba);
  }
 );
-// *INDENT-ON*
+// clang-format on
 
 GrayscaleProc::GrayscaleProc() {
     // set defaults
@@ -71,17 +73,16 @@ GrayscaleProc::GrayscaleProc() {
 }
 
 void GrayscaleProc::setIdentity() {
-
 }
 
 void GrayscaleProc::setUniforms() {
-    if(inputConvType != GRAYSCALE_INPUT_CONVERSION_NONE) {
-        glUniform3fv(shParamUInputConvVec, 1, grayscaleConvVec);  // set additional uniforms
+    if (inputConvType != GRAYSCALE_INPUT_CONVERSION_NONE) {
+        glUniform3fv(shParamUInputConvVec, 1, grayscaleConvVec); // set additional uniforms
     }
 }
 
 void GrayscaleProc::getUniforms() {
-    if(inputConvType != GRAYSCALE_INPUT_CONVERSION_NONE) {
+    if (inputConvType != GRAYSCALE_INPUT_CONVERSION_NONE) {
         shParamUInputConvVec = shader->getParam(UNIF, "uInputConvVec");
     }
 }
@@ -92,11 +93,12 @@ void GrayscaleProc::setGrayscaleConvVec(const GLfloat v[3]) {
 }
 
 void GrayscaleProc::setGrayscaleConvType(GrayscaleInputConversionType type) {
-    if (inputConvType == type) return;  // no change
+    if (inputConvType == type)
+        return; // no change
 
-    const GLfloat *v = NULL;
+    const GLfloat* v = NULL;
 
-    switch(type) {
+    switch (type) {
     case GRAYSCALE_INPUT_CONVERSION_RGB:
         v = &grayscaleConvVecRGB[0];
         break;

--- a/ogles_gpgpu/common/proc/grayscale.h
+++ b/ogles_gpgpu/common/proc/grayscale.h
@@ -25,10 +25,10 @@ namespace ogles_gpgpu {
  * Define grayscale conversion types
  */
 typedef enum {
-    GRAYSCALE_INPUT_CONVERSION_NONE     = -2,
-    GRAYSCALE_INPUT_CONVERSION_CUSTOM   = -1,
-    GRAYSCALE_INPUT_CONVERSION_RGB      = 0,
-    GRAYSCALE_INPUT_CONVERSION_BGR      = 1,
+    GRAYSCALE_INPUT_CONVERSION_NONE = -2,
+    GRAYSCALE_INPUT_CONVERSION_CUSTOM = -1,
+    GRAYSCALE_INPUT_CONVERSION_RGB = 0,
+    GRAYSCALE_INPUT_CONVERSION_BGR = 1,
 } GrayscaleInputConversionType;
 
 /**
@@ -45,7 +45,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "GrayscaleProc";
     }
 
@@ -62,7 +62,7 @@ public:
     /**
      * Get weighted channel grayscale conversion vector.
      */
-    const GLfloat *getGrayscaleConvVec() const {
+    const GLfloat* getGrayscaleConvVec() const {
         return grayscaleConvVec;
     }
 
@@ -79,11 +79,10 @@ public:
     }
 
 private:
-
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return inputConvType == GRAYSCALE_INPUT_CONVERSION_NONE ? fshaderNoopSrc : fshaderGrayscaleSrc;
     }
 
@@ -97,15 +96,15 @@ private:
      */
     virtual void getUniforms();
 
-    static const char *fshaderNoopSrc;              // Noop pass through shader
-    static const char *fshaderGrayscaleSrc;         // fragment shader source
-    static const GLfloat grayscaleConvVecRGB[3];    // weighted channel grayscale conversion for RGB input (default)
-    static const GLfloat grayscaleConvVecBGR[3];    // weighted channel grayscale conversion for BGR input
-    static const GLfloat grayscaleConvVecNone[3];   // identity transformation for pass through shader behavior
+    static const char* fshaderNoopSrc; // Noop pass through shader
+    static const char* fshaderGrayscaleSrc; // fragment shader source
+    static const GLfloat grayscaleConvVecRGB[3]; // weighted channel grayscale conversion for RGB input (default)
+    static const GLfloat grayscaleConvVecBGR[3]; // weighted channel grayscale conversion for BGR input
+    static const GLfloat grayscaleConvVecNone[3]; // identity transformation for pass through shader behavior
 
     GLint shParamUInputConvVec; // shader uniform weighted channel grayscale conversion vector
 
-    GLfloat grayscaleConvVec[3];                // currently set weighted channel grayscale conversion vector
+    GLfloat grayscaleConvVec[3]; // currently set weighted channel grayscale conversion vector
     GrayscaleInputConversionType inputConvType; // grayscale conversion type
 };
 }

--- a/ogles_gpgpu/common/proc/harris.cpp
+++ b/ogles_gpgpu/common/proc/harris.cpp
@@ -6,22 +6,22 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "harris.h"
+#include "../common_includes.h"
 
 using namespace std;
 using namespace ogles_gpgpu;
 
 // Try Harris:
 
-// *INDENT-OFF*
-const char *HarrisProc::fshaderHarrisSrc = OG_TO_STR(
+// clang-format off
+const char *HarrisProc::fshaderHarrisSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
-varying OGLES_GPGPU_HIGHP vec2 textureCoordinate;
+OG_TO_STR(
+varying vec2 textureCoordinate;
 
 uniform sampler2D inputImageTexture;
 uniform float sensitivity;
@@ -39,15 +39,13 @@ void main()
 
     gl_FragColor = vec4(vec3(cornerness * sensitivity), 1.0);
 });
-// *INDENT-ON*
+// clang-format on
 
 HarrisProc::HarrisProc() {
-
 }
 
-
 // TODO: We need to override this if we are using the GPUImage shaders
-void HarrisProc::filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target) {
+void HarrisProc::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target) {
     // create shader object
     ProcBase::createShader(vShaderSrc, fShaderSrc, target);
 
@@ -60,10 +58,10 @@ void HarrisProc::filterShaderSetup(const char *vShaderSrc, const char *fShaderSr
 void HarrisProc::getUniforms() {
     FilterProcBase::getUniforms();
     shParamUInputTex = shader->getParam(UNIF, "inputImageTexture");
-    shParamUInputSensitivity =  shader->getParam(UNIF, "sensitivity");
+    shParamUInputSensitivity = shader->getParam(UNIF, "sensitivity");
 }
 
 void HarrisProc::setUniforms() {
     FilterProcBase::setUniforms();
-    glUniform1f (shParamUInputSensitivity, sensitivity);   // set additional uniforms
+    glUniform1f(shParamUInputSensitivity, sensitivity); // set additional uniforms
 }

--- a/ogles_gpgpu/common/proc/harris.h
+++ b/ogles_gpgpu/common/proc/harris.h
@@ -31,7 +31,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "HarrisProc";
     }
 
@@ -50,7 +50,6 @@ public:
     }
 
 private:
-
     /**
      * Set additional uniforms.
      */
@@ -62,23 +61,23 @@ private:
     virtual void getUniforms();
 
     // TODO: we currently need to override the filterShaderSetup to parse uniforms from the GPUImage
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
 
     /**
      * Get the vertex shader source.
      */
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderGPUImage;
     }
 
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderHarrisSrc;
     }
 
-    static const char *fshaderHarrisSrc;         // fragment shader source
+    static const char* fshaderHarrisSrc; // fragment shader source
 
     GLuint shParamUInputSensitivity = 0;
 

--- a/ogles_gpgpu/common/proc/hessian.cpp
+++ b/ogles_gpgpu/common/proc/hessian.cpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "hessian.h"
+#include "../common_includes.h"
 
 //>> fx=[-1 1; -1 1]; fy=[-1 -1; 1 1];
 //
@@ -40,13 +40,13 @@ using namespace ogles_gpgpu;
 
 // Source: GPUImageXYDerivativeFilter.m
 
-// *INDENT-OFF*
-const char *HessianProc::fshaderHessianAndDeterminantSrc = OG_TO_STR(
+// clang-format off
+const char *HessianProc::fshaderHessianAndDeterminantSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
 varying vec2 textureCoordinate;
 varying vec2 leftTextureCoordinate;
 varying vec2 rightTextureCoordinate;
@@ -102,15 +102,15 @@ void main()
 
     gl_FragColor = vec4((Ixx + 1.0)/2.0, (Iyy + 1.0)/2.0, (Ixy + 1.0)/2.0, d * edgeStrength);
 });
-// *INDENT-ON*
+// clang-format on
 
-// *INDENT-OFF*
-const char *HessianProc::fshaderDeterminantSrc = OG_TO_STR(
+// clang-format off
+const char *HessianProc::fshaderDeterminantSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+ OG_TO_STR(precision highp float;)
 #endif
-
+ OG_TO_STR(
  varying vec2 textureCoordinate;
  varying vec2 leftTextureCoordinate;
  varying vec2 rightTextureCoordinate;
@@ -165,12 +165,11 @@ const char *HessianProc::fshaderDeterminantSrc = OG_TO_STR(
 
     gl_FragColor = vec4(d * edgeStrength, 1.0);
 });
-// *INDENT-ON*
+// clang-format on
 
 HessianProc::HessianProc(float edgeStrength, bool doHessian)
     : doHessian(doHessian)
     , edgeStrength(edgeStrength) {
-
 }
 
 void HessianProc::setUniforms() {
@@ -183,4 +182,3 @@ void HessianProc::getUniforms() {
     shParamUInputTex = shader->getParam(UNIF, "inputImageTexture");
     shParamUEdgeStrength = shader->getParam(UNIF, "edgeStrength");
 }
-

--- a/ogles_gpgpu/common/proc/hessian.h
+++ b/ogles_gpgpu/common/proc/hessian.h
@@ -24,12 +24,12 @@ public:
     /**
      * Constructor.
      */
-    HessianProc(float edgeStrength=1.f, bool doHessian=true);
+    HessianProc(float edgeStrength = 1.f, bool doHessian = true);
 
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "HessianProc";
     }
 
@@ -42,11 +42,10 @@ public:
     }
 
 private:
-
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return doHessian ? fshaderHessianAndDeterminantSrc : fshaderDeterminantSrc;
     }
 
@@ -66,9 +65,9 @@ private:
 
     GLuint shParamUEdgeStrength = 0;
 
-    static const char *fshaderHessianAndDeterminantSrc;   // fragment shader source
+    static const char* fshaderHessianAndDeterminantSrc; // fragment shader source
 
-    static const char *fshaderDeterminantSrc;   // fragment shader source
+    static const char* fshaderDeterminantSrc; // fragment shader source
 };
 }
 

--- a/ogles_gpgpu/common/proc/highpass.h
+++ b/ogles_gpgpu/common/proc/highpass.h
@@ -15,9 +15,11 @@ BEGIN_OGLES_GPGPU
 
 class HighPassFilterProc : public IirFilterProc {
 public:
-    HighPassFilterProc(float alpha=0.5) : IirFilterProc(IirFilterProc::kHighPass, alpha) {}
+    HighPassFilterProc(float alpha = 0.5)
+        : IirFilterProc(IirFilterProc::kHighPass, alpha) {
+    }
     ~HighPassFilterProc() {}
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "HighPassFilterProc";
     }
 };

--- a/ogles_gpgpu/common/proc/hsv2rgb.cpp
+++ b/ogles_gpgpu/common/proc/hsv2rgb.cpp
@@ -11,13 +11,12 @@
 #include "hsv2rgb.h"
 
 BEGIN_OGLES_GPGPU
-// *INDENT-OFF*
-const char * Hsv2RgbProc::fshaderHsv2RgbSrc = OG_TO_STR
-(
+// clang-format off
+const char * Hsv2RgbProc::fshaderHsv2RgbSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
   vec3 hsv2rgb(vec3 c)
   {
     vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
@@ -27,11 +26,10 @@ const char * Hsv2RgbProc::fshaderHsv2RgbSrc = OG_TO_STR
 
  varying vec2 vTexCoord;
  uniform sampler2D uInputTex;
- uniform float gain;
  void main()
  {
      vec4 val = texture2D(uInputTex, vTexCoord);
      gl_FragColor = vec4(hsv2rgb(val.rgb), 1.0);
  });
-// *INDENT-ON*
+// clang-format on
 END_OGLES_GPGPU

--- a/ogles_gpgpu/common/proc/hsv2rgb.h
+++ b/ogles_gpgpu/common/proc/hsv2rgb.h
@@ -11,29 +11,24 @@
 #ifndef OGLES_GPGPU_COMMON_HSV2RGB_PROC
 #define OGLES_GPGPU_COMMON_HSV2RGB_PROC
 
+#include "../common_includes.h"
 #include "ogles_gpgpu/common/proc/base/filterprocbase.h"
 
 BEGIN_OGLES_GPGPU
 
 class Hsv2RgbProc : public ogles_gpgpu::FilterProcBase {
 public:
-    Hsv2RgbProc(float gain=1.f) : gain(gain) {}
-    virtual const char *getProcName() {
+    Hsv2RgbProc() {}
+    virtual const char* getProcName() {
         return "Hsv2RgbProc";
     }
+
 private:
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderHsv2RgbSrc;
     }
-    virtual void getUniforms() {
-        shParamUGain = shader->getParam(UNIF, "gain");
-    }
-    virtual void setUniforms() {
-        glUniform1f(shParamUGain, gain);
-    }
-    static const char *fshaderHsv2RgbSrc; // fragment shader source
-    float gain = 1.f;
-    GLint shParamUGain;
+
+    static const char* fshaderHsv2RgbSrc; // fragment shader source
 };
 
 END_OGLES_GPGPU

--- a/ogles_gpgpu/common/proc/iir.cpp
+++ b/ogles_gpgpu/common/proc/iir.cpp
@@ -7,9 +7,9 @@
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
 #include "iir.h"
-#include "fifo.h"
 #include "blend.h"
 #include "diff.h"
+#include "fifo.h"
 
 /////////////////////////////
 //          +===============+
@@ -32,7 +32,7 @@ public:
         , diffProc(strength) {
         iirProc.add(&fifoProc);
         fifoProc.add(&iirProc, 1);
-        if(kind == kHighPass) {
+        if (kind == kHighPass) {
             iirProc.add(&diffProc, 1);
             lastProc = &diffProc; // high pass output
         }
@@ -42,7 +42,7 @@ public:
     BlendProc iirProc;
     FIFOPRoc fifoProc;
     DiffProc diffProc;
-    ProcInterface *lastProc = &iirProc; // default for low pass
+    ProcInterface* lastProc = &iirProc; // default for low pass
 };
 
 IirFilterProc::IirFilterProc(FilterKind kind, float alpha, float strength) {
@@ -50,7 +50,7 @@ IirFilterProc::IirFilterProc(FilterKind kind, float alpha, float strength) {
     m_impl = std::unique_ptr<Impl>(new Impl(kind, alpha, strength));
     procPasses.push_back(&m_impl->iirProc);
     procPasses.push_back(&m_impl->fifoProc);
-    if(kind == kHighPass) {
+    if (kind == kHighPass) {
         procPasses.push_back(&m_impl->diffProc);
     }
 }
@@ -82,7 +82,7 @@ int IirFilterProc::render(int position) {
     // TODO: We don't really need this to call fifoProc->useTexture(),
     // if it is done by this class (see below for special case first frame handling)
     m_impl->iirProc.process(0);
-    if(m_impl->kind == kHighPass) {
+    if (m_impl->kind == kHighPass) {
         // At this point useTexture() has been called and diffProc should have:
         // texture #1 : <- Input
         // texture #2 : <- IirProc
@@ -92,15 +92,15 @@ int IirFilterProc::render(int position) {
 }
 
 void IirFilterProc::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int position) {
-    auto &fifoProc = m_impl->fifoProc;
-    auto &iirProc = m_impl->iirProc;
+    auto& fifoProc = m_impl->fifoProc;
+    auto& iirProc = m_impl->iirProc;
 
-    if(m_impl->kind == kHighPass) {
-        auto &diffProc = m_impl->diffProc;
+    if (m_impl->kind == kHighPass) {
+        auto& diffProc = m_impl->diffProc;
 
         // (Optional) Diff filter for high pass filter:
         diffProc.useTexture(id, useTexUnit, target, 0);
-        if(isFirst) {
+        if (isFirst) {
             diffProc.useTexture2(id, useTexUnit, GL_TEXTURE_2D);
         } else {
             diffProc.useTexture2(iirProc.getOutputTexId(), iirProc.getTextureUnit(), GL_TEXTURE_2D);
@@ -109,7 +109,7 @@ void IirFilterProc::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int 
 
     // IIR filter input (same image for first frame)
 
-    if(isFirst) {
+    if (isFirst) {
         isFirst = false;
         iirProc.useTexture(id, useTexUnit, target, 0);
         iirProc.useTexture2(id, useTexUnit, GL_TEXTURE_2D);
@@ -123,7 +123,6 @@ void IirFilterProc::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int 
 
         // FIFO input (from IIR)
         fifoProc.useTexture(iirProc.getOutputTexId(), iirProc.getTextureUnit(), GL_TEXTURE_2D, 0);
-
     }
 }
 

--- a/ogles_gpgpu/common/proc/iir.h
+++ b/ogles_gpgpu/common/proc/iir.h
@@ -16,7 +16,6 @@ BEGIN_OGLES_GPGPU
 
 class IirFilterProc : public MultiPassProc {
 public:
-
     enum FilterKind {
         kLowPass,
         kHighPass
@@ -24,11 +23,11 @@ public:
 
     class Impl;
 
-    IirFilterProc(FilterKind kind, float alpha=0.5, float strength=1.f);
+    IirFilterProc(FilterKind kind, float alpha = 0.5, float strength = 1.f);
     ~IirFilterProc();
-    virtual void useTexture(GLuint id, GLuint useTexUnit = 1, GLenum target = GL_TEXTURE_2D, int position=0);
-    virtual int render(int position=0);
-    virtual const char *getProcName() {
+    virtual void useTexture(GLuint id, GLuint useTexUnit = 1, GLenum target = GL_TEXTURE_2D, int position = 0);
+    virtual int render(int position = 0);
+    virtual const char* getProcName() {
         return "IirFilterProc";
     }
     virtual ProcInterface* getInputFilter() const;

--- a/ogles_gpgpu/common/proc/ixyt.cpp
+++ b/ogles_gpgpu/common/proc/ixyt.cpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "ixyt.h"
+#include "../common_includes.h"
 
 using namespace ogles_gpgpu;
 
@@ -20,18 +20,17 @@ void IxytProc::getUniforms() {
 
 void IxytProc::setUniforms() {
     TwoInputProc::setUniforms();
-    glUniform1f(texelWidthUniform, (1.0f/ float(outFrameW)));
-    glUniform1f(texelHeightUniform, (1.0f/ float(outFrameH)));
+    glUniform1f(texelWidthUniform, (1.0f / float(outFrameW)));
+    glUniform1f(texelHeightUniform, (1.0f / float(outFrameH)));
     glUniform1f(shParamUStrength, strength);
 }
 
-// *INDENT-OFF*
-const char *IxytProc::fshaderIxytSrc = OG_TO_STR
-(
+// clang-format off
+const char *IxytProc::fshaderIxytSrc =
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  varying vec2 leftTextureCoordinate;
  varying vec2 rightTextureCoordinate;
@@ -78,4 +77,4 @@ const char *IxytProc::fshaderIxytSrc = OG_TO_STR
      gl_FragColor = vec4(d2, centerIntensity);
  }
  );
-// *INDENT-ON*
+// clang-format on

--- a/ogles_gpgpu/common/proc/ixyt.h
+++ b/ogles_gpgpu/common/proc/ixyt.h
@@ -16,12 +16,12 @@ namespace ogles_gpgpu {
 
 // ######### Temporal derivative shader #################
 
-
 class IxytProc : public TwoInputProc {
 public:
-
-    IxytProc(float strength = 1.0f) : strength(strength) {}
-    virtual const char *getProcName() {
+    IxytProc(float strength = 1.0f)
+        : strength(strength) {
+    }
+    virtual const char* getProcName() {
         return "IxytProc";
     }
     virtual void getUniforms();
@@ -29,21 +29,21 @@ public:
     virtual void setStrength(float value) {
         strength = value;
     }
-private:
 
+private:
     GLint texelWidthUniform;
     GLint texelHeightUniform;
 
     GLint shParamUStrength;
     float strength = 1.f;
 
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderFilter3x3Src;
     }
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderIxytSrc;
     }
-    static const char *fshaderIxytSrc;   // fragment shader source
+    static const char* fshaderIxytSrc; // fragment shader source
 };
 }
 

--- a/ogles_gpgpu/common/proc/lbp.cpp
+++ b/ogles_gpgpu/common/proc/lbp.cpp
@@ -6,19 +6,19 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "lbp.h"
+#include "../common_includes.h"
 
 using namespace std;
 using namespace ogles_gpgpu;
 
-// *INDENT-OFF*
-const char *LbpProc::fshaderLbpSrc = OG_TO_STR(
+// clang-format off
+const char *LbpProc::fshaderLbpSrc =
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
 varying vec2 textureCoordinate;
 varying vec2 leftTextureCoordinate;
 varying vec2 rightTextureCoordinate;
@@ -35,17 +35,17 @@ uniform sampler2D inputImageTexture;
 
 void main()
 {
-   OGLES_GPGPU_LOWP float centerIntensity = texture2D(inputImageTexture, textureCoordinate).r;
-   OGLES_GPGPU_LOWP float bottomLeftIntensity = texture2D(inputImageTexture, bottomLeftTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float topRightIntensity = texture2D(inputImageTexture, topRightTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float topLeftIntensity = texture2D(inputImageTexture, topLeftTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float bottomRightIntensity = texture2D(inputImageTexture, bottomRightTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float leftIntensity = texture2D(inputImageTexture, leftTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float rightIntensity = texture2D(inputImageTexture, rightTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float bottomIntensity = texture2D(inputImageTexture, bottomTextureCoordinate).r;
-   OGLES_GPGPU_LOWP float topIntensity = texture2D(inputImageTexture, topTextureCoordinate).r;
+    float centerIntensity = texture2D(inputImageTexture, textureCoordinate).r;
+    float bottomLeftIntensity = texture2D(inputImageTexture, bottomLeftTextureCoordinate).r;
+    float topRightIntensity = texture2D(inputImageTexture, topRightTextureCoordinate).r;
+    float topLeftIntensity = texture2D(inputImageTexture, topLeftTextureCoordinate).r;
+    float bottomRightIntensity = texture2D(inputImageTexture, bottomRightTextureCoordinate).r;
+    float leftIntensity = texture2D(inputImageTexture, leftTextureCoordinate).r;
+    float rightIntensity = texture2D(inputImageTexture, rightTextureCoordinate).r;
+    float bottomIntensity = texture2D(inputImageTexture, bottomTextureCoordinate).r;
+    float topIntensity = texture2D(inputImageTexture, topTextureCoordinate).r;
 
-   OGLES_GPGPU_LOWP float byteTally = 1.0 / 255.0 * step(centerIntensity, topRightIntensity);
+    float byteTally = 1.0 / 255.0 * step(centerIntensity, topRightIntensity);
    byteTally += 2.0 / 255.0 * step(centerIntensity, topIntensity);
    byteTally += 4.0 / 255.0 * step(centerIntensity, topLeftIntensity);
    byteTally += 8.0 / 255.0 * step(centerIntensity, leftIntensity);
@@ -60,10 +60,9 @@ void main()
     //gl_FragColor = vec4(centerIntensity, centerIntensity, centerIntensity, 1.0);
     gl_FragColor = vec4(byteTally, byteTally, byteTally, 1.0);
 });
-// *INDENT-ON*
+// clang-format on
 
 LbpProc::LbpProc() {
-
 }
 
 void LbpProc::getUniforms() {

--- a/ogles_gpgpu/common/proc/lbp.h
+++ b/ogles_gpgpu/common/proc/lbp.h
@@ -29,16 +29,15 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "LbpProc";
     }
 
 private:
-
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderLbpSrc;
     }
 
@@ -47,7 +46,7 @@ private:
      */
     virtual void getUniforms();
 
-    static const char *fshaderLbpSrc;   // fragment shader source
+    static const char* fshaderLbpSrc; // fragment shader source
 };
 }
 

--- a/ogles_gpgpu/common/proc/lnorm.h
+++ b/ogles_gpgpu/common/proc/lnorm.h
@@ -17,9 +17,9 @@
 namespace ogles_gpgpu {
 class LocalNormProc : public MultiPassProc {
 public:
-    LocalNormProc(float normConst=0.005) {
-        LocalNormPass *localNormPass1 = new LocalNormPass(1);
-        LocalNormPass *localNormPass2 = new LocalNormPass(2, normConst);
+    LocalNormProc(float normConst = 0.005) {
+        LocalNormPass* localNormPass1 = new LocalNormPass(1);
+        LocalNormPass* localNormPass2 = new LocalNormPass(2, normConst);
 
         procPasses.push_back(localNormPass1);
         procPasses.push_back(localNormPass2);
@@ -28,7 +28,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "LocalNormProc";
     }
 };

--- a/ogles_gpgpu/common/proc/lowpass.h
+++ b/ogles_gpgpu/common/proc/lowpass.h
@@ -15,9 +15,11 @@ BEGIN_OGLES_GPGPU
 
 class LowPassFilterProc : public IirFilterProc {
 public:
-    LowPassFilterProc(float alpha=0.5) : IirFilterProc(IirFilterProc::kLowPass, alpha) {}
+    LowPassFilterProc(float alpha = 0.5)
+        : IirFilterProc(IirFilterProc::kLowPass, alpha) {
+    }
     ~LowPassFilterProc() {}
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "LowPassFilterProc";
     }
 };

--- a/ogles_gpgpu/common/proc/median.cpp
+++ b/ogles_gpgpu/common/proc/median.cpp
@@ -50,14 +50,16 @@
 
 BEGIN_OGLES_GPGPU
 
-MedianProc::MedianProc() : Filter3x3Proc() {}
+MedianProc::MedianProc()
+    : Filter3x3Proc() {
+}
 
-// *INDENT-OFF*
-const char *MedianProc::fshaderMedianSrc = OG_TO_STR
-(
+// clang-format off
+const char *MedianProc::fshaderMedianSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
+OG_TO_STR(
 
  varying vec2 textureCoordinate;
  varying vec2 leftTextureCoordinate;
@@ -76,7 +78,6 @@ const char *MedianProc::fshaderMedianSrc = OG_TO_STR
 #define s2(a, b)				temp = a; a = min(a, b); b = max(temp, b);
 #define mn3(a, b, c)			s2(a, b); s2(a, c);
 #define mx3(a, b, c)			s2(b, c); s2(a, c);
-
 #define mnmx3(a, b, c)			mx3(a, b, c); s2(a, b);                                   // 3 exchanges
 #define mnmx4(a, b, c, d)		s2(a, b); s2(c, d); s2(a, c); s2(b, d);                   // 4 exchanges
 #define mnmx5(a, b, c, d, e)	s2(a, b); s2(c, d); mn3(a, c, e); mx3(b, d, e);           // 6 exchanges
@@ -85,15 +86,12 @@ const char *MedianProc::fshaderMedianSrc = OG_TO_STR
  void main()
  {
      vec3 v[6];
-
      v[0] = texture2D(inputImageTexture, bottomLeftTextureCoordinate).rgb;
      v[1] = texture2D(inputImageTexture, topRightTextureCoordinate).rgb;
      v[2] = texture2D(inputImageTexture, topLeftTextureCoordinate).rgb;
      v[3] = texture2D(inputImageTexture, bottomRightTextureCoordinate).rgb;
      v[4] = texture2D(inputImageTexture, leftTextureCoordinate).rgb;
      v[5] = texture2D(inputImageTexture, rightTextureCoordinate).rgb;
-//     v[6] = texture2D(inputImageTexture, bottomTextureCoordinate).rgb;
-//     v[7] = texture2D(inputImageTexture, topTextureCoordinate).rgb;
      vec3 temp;
 
      mnmx6(v[0], v[1], v[2], v[3], v[4], v[5]);
@@ -112,7 +110,7 @@ const char *MedianProc::fshaderMedianSrc = OG_TO_STR
 
      gl_FragColor = vec4(v[4], 1.0);
  });
-// *INDENT-ON*
+// clang-format on
 
 void MedianProc::getUniforms() {
     Filter3x3Proc::getUniforms();

--- a/ogles_gpgpu/common/proc/median.h
+++ b/ogles_gpgpu/common/proc/median.h
@@ -29,16 +29,15 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "MedianProc";
     }
 
 private:
-
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderMedianSrc;
     }
 
@@ -47,7 +46,7 @@ private:
      */
     virtual void getUniforms();
 
-    static const char *fshaderMedianSrc;   // fragment shader source
+    static const char* fshaderMedianSrc; // fragment shader source
 };
 
 END_OGLES_GPGPU

--- a/ogles_gpgpu/common/proc/multipass/adapt_thresh_pass.cpp
+++ b/ogles_gpgpu/common/proc/multipass/adapt_thresh_pass.cpp
@@ -7,9 +7,8 @@
 // See LICENSE file in project repository root for the license.
 //
 
-
-#include "../../common_includes.h"
 #include "adapt_thresh_pass.h"
+#include "../../common_includes.h"
 
 using namespace ogles_gpgpu;
 
@@ -17,13 +16,13 @@ using namespace ogles_gpgpu;
 // Perform a vertical 5x1 average gray pixel value calculation
 // Requires a grayscale image as input!
 
-// *INDENT-OFF*
-const char *AdaptThreshProcPass::fshaderAdaptThreshPass1Src = OG_TO_STR(
+// clang-format off
+const char *AdaptThreshProcPass::fshaderAdaptThreshPass1Src = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
 varying vec2 vTexCoord;
 uniform vec2 uPxD;
 uniform sampler2D uInputTex;
@@ -42,19 +41,19 @@ void main() {
     gl_FragColor = vec4(avg, centerGray, 0.0, 1.0);
 }
 );
-// *INDENT-ON*
+// clang-format on
 
 // Adaptive thresholding - Pass 2
 // Perform a horizontal 7x1 or 5x1 average gray pixel value calculation and
 // the final binarization
 
-// *INDENT-OFF*
-const char *AdaptThreshProcPass::fshaderAdaptThreshPass2Src = OG_TO_STR(
+// clang-format off
+const char *AdaptThreshProcPass::fshaderAdaptThreshPass2Src = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
 varying vec2 vTexCoord;
 uniform vec2 uPxD;
 uniform sampler2D uInputTex;
@@ -76,7 +75,7 @@ void main()
     gl_FragColor = vec4(bin, bin, bin, 1.0);
 }
 );
-// *INDENT-ON*
+// clang-format on
 
 int AdaptThreshProcPass::init(int inW, int inH, unsigned int order, bool prepareForExternalInput) {
     OG_LOGINF(getProcName(), "render pass %d", renderPass);
@@ -92,7 +91,7 @@ int AdaptThreshProcPass::init(int inW, int inH, unsigned int order, bool prepare
     pxDy = 1.0f / (float)outFrameH;
 
     // get necessary fragment shader source
-    const char *shSrc = renderPass == 1 ? fshaderAdaptThreshPass1Src : fshaderAdaptThreshPass2Src;
+    const char* shSrc = renderPass == 1 ? fshaderAdaptThreshPass1Src : fshaderAdaptThreshPass2Src;
 
     // FilterProcBase init - create shaders, get shader params, set buffers for OpenGL
     filterInit(vshaderDefault, shSrc, RenderOrientationDiagonal);
@@ -107,7 +106,7 @@ void AdaptThreshProcPass::createFBOTex(bool genMipmap) {
     assert(fbo);
 
     if (renderPass == 1) {
-        fbo->createAttachedTex(outFrameH, outFrameW, genMipmap);   // swapped
+        fbo->createAttachedTex(outFrameH, outFrameW, genMipmap); // swapped
     } else {
         fbo->createAttachedTex(outFrameW, outFrameH, genMipmap);
     }
@@ -122,7 +121,7 @@ int AdaptThreshProcPass::render(int position) {
 
     filterRenderPrepare();
 
-    glUniform2f(shParamUPxD, pxDx, pxDy);	// texture pixel delta values
+    glUniform2f(shParamUPxD, pxDx, pxDy); // texture pixel delta values
 
     Tools::checkGLErr(getProcName(), "render prepare");
 

--- a/ogles_gpgpu/common/proc/multipass/adapt_thresh_pass.h
+++ b/ogles_gpgpu/common/proc/multipass/adapt_thresh_pass.h
@@ -28,17 +28,18 @@ public:
     /**
      * Construct as render pass <pass> (1 or 2).
      */
-    AdaptThreshProcPass(int pass) : FilterProcBase(),
-        renderPass(pass),
-        pxDx(0.0f),
-        pxDy(0.0f) {
+    AdaptThreshProcPass(int pass)
+        : FilterProcBase()
+        , renderPass(pass)
+        , pxDx(0.0f)
+        , pxDy(0.0f) {
         assert(renderPass == 1 || renderPass == 2);
     }
 
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "AdaptThreshProcPass";
     }
 
@@ -58,18 +59,18 @@ public:
     /**
      * Render the output.
      */
-    virtual int render(int position=0);
+    virtual int render(int position = 0);
 
 private:
     int renderPass; // render pass number. must be 1 or 2
 
-    GLint shParamUPxD;		// pixel delta values for texture lookup in the fragment shader. only used for adapt. thresholding
+    GLint shParamUPxD; // pixel delta values for texture lookup in the fragment shader. only used for adapt. thresholding
 
-    float pxDx;	// pixel delta value for texture access. only used for adapt. thresholding
-    float pxDy;	// pixel delta value for texture access. only used for adapt. thresholding
+    float pxDx; // pixel delta value for texture access. only used for adapt. thresholding
+    float pxDy; // pixel delta value for texture access. only used for adapt. thresholding
 
-    static const char *fshaderAdaptThreshPass1Src;  // fragment shader source for adaptive thresholding pass 1
-    static const char *fshaderAdaptThreshPass2Src;  // fragment shader source for adaptive thresholding pass 2
+    static const char* fshaderAdaptThreshPass1Src; // fragment shader source for adaptive thresholding pass 1
+    static const char* fshaderAdaptThreshPass2Src; // fragment shader source for adaptive thresholding pass 2
 };
 }
 

--- a/ogles_gpgpu/common/proc/multipass/box_opt_pass.cpp
+++ b/ogles_gpgpu/common/proc/multipass/box_opt_pass.cpp
@@ -4,8 +4,8 @@
 // See LICENSE file in project repository root for the license.
 //
 
-#include "../../common_includes.h"
 #include "box_opt_pass.h"
+#include "../../common_includes.h"
 
 #include <cmath>
 
@@ -25,7 +25,7 @@ static std::string vertexShaderForOptimizedBoxBlur(int blurRadius, float sigma) 
     ss << "attribute vec4 inputTextureCoordinate;\n";
     ss << "uniform float texelWidthOffset;\n";
     ss << "uniform float texelHeightOffset;\n\n";
-    ss << "varying vec2 blurCoordinates[" << (unsigned long)(1 + (numberOfOptimizedOffsets * 2)) <<  "];\n\n";
+    ss << "varying vec2 blurCoordinates[" << (unsigned long)(1 + (numberOfOptimizedOffsets * 2)) << "];\n\n";
     ss << "void main()\n";
     ss << "{\n";
     ss << "   gl_Position = position;\n";
@@ -49,7 +49,7 @@ static std::string fragmentShaderForOptimizedBoxBlur(int blurRadius, float sigma
     assert(blurRadius > 1);
 
     // From these weights we calculate the offsets to read interpolated values from
-    int numberOfOptimizedOffsets =  getNumberOfOptimizedOffsets(blurRadius);
+    int numberOfOptimizedOffsets = getNumberOfOptimizedOffsets(blurRadius);
     int trueNumberOfOptimizedOffsets = blurRadius / 2 + (blurRadius % 2);
 
     std::stringstream ss;
@@ -72,8 +72,8 @@ static std::string fragmentShaderForOptimizedBoxBlur(int blurRadius, float sigma
     for (int currentBlurCoordinateIndex = 0; currentBlurCoordinateIndex < numberOfOptimizedOffsets; currentBlurCoordinateIndex++) {
         int index1 = (unsigned long)((currentBlurCoordinateIndex * 2) + 1);
         int index2 = (unsigned long)((currentBlurCoordinateIndex * 2) + 2);
-        ss << "   sum += texture2D(inputImageTexture, blurCoordinates[" << index1 << "]) * " << boxWeight2 <<";\n";
-        ss << "   sum += texture2D(inputImageTexture, blurCoordinates[" << index2 << "]) * " << boxWeight2  <<";\n";
+        ss << "   sum += texture2D(inputImageTexture, blurCoordinates[" << index1 << "]) * " << boxWeight2 << ";\n";
+        ss << "   sum += texture2D(inputImageTexture, blurCoordinates[" << index2 << "]) * " << boxWeight2 << ";\n";
     }
 
     // If the number of required samples exceeds the amount we can pass in via varyings, we have to do dependent texture reads in the fragment shader
@@ -93,7 +93,6 @@ static std::string fragmentShaderForOptimizedBoxBlur(int blurRadius, float sigma
     return ss.str();
 }
 
-
 void BoxOptProcPass::setRadius(float newValue) {
     float newBlurRadius = round(round(newValue / 2.0) * 2.0);
 
@@ -112,7 +111,7 @@ void BoxOptProcPass::setRadius(float newValue) {
 }
 
 // TODO: We need to override this if we are using the GPUImage shaders
-void BoxOptProcPass::filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target) {
+void BoxOptProcPass::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target) {
     // create shader object
     ProcBase::createShader(vShaderSrc, fShaderSrc, target);
 
@@ -141,13 +140,10 @@ void BoxOptProcPass::getUniforms() {
     shParamUTexelHeightOffset = shader->getParam(UNIF, "texelHeightOffset");
 }
 
-const char *BoxOptProcPass::getFragmentShaderSource() {
+const char* BoxOptProcPass::getFragmentShaderSource() {
     return fshaderBoxSrc.c_str();
 }
 
-const char *BoxOptProcPass::getVertexShaderSource() {
+const char* BoxOptProcPass::getVertexShaderSource() {
     return vshaderBoxSrc.c_str();
 }
-
-
-

--- a/ogles_gpgpu/common/proc/multipass/box_opt_pass.h
+++ b/ogles_gpgpu/common/proc/multipass/box_opt_pass.h
@@ -40,22 +40,21 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "BoxOptProcPass";
     }
 
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
     virtual void setUniforms();
     virtual void getUniforms();
-    virtual const char *getFragmentShaderSource();
-    virtual const char *getVertexShaderSource();
+    virtual const char* getFragmentShaderSource();
+    virtual const char* getVertexShaderSource();
 
 private:
-
     int renderPass; // render pass number. must be 1 or 2
 
-    float pxDx;	// pixel delta value for texture access
-    float pxDy;	// pixel delta value for texture access
+    float pxDx; // pixel delta value for texture access
+    float pxDy; // pixel delta value for texture access
 
     float _blurRadiusInPixels = 0.0; // start 0 (uninitialized)
 
@@ -65,6 +64,5 @@ private:
     std::string vshaderBoxSrc;
     std::string fshaderBoxSrc;
 };
-
 }
 #endif

--- a/ogles_gpgpu/common/proc/multipass/gauss_opt_pass.h
+++ b/ogles_gpgpu/common/proc/multipass/gauss_opt_pass.h
@@ -26,7 +26,7 @@ public:
     /**
      * Construct as render pass <pass> (1 or 2).
      */
-    GaussOptProcPass(int pass, float radius, bool doNorm=false, float normConst=0.005f)
+    GaussOptProcPass(int pass, float radius, bool doNorm = false, float normConst = 0.005f)
         : FilterProcBase()
         , doNorm(doNorm)
         , renderPass(pass)
@@ -42,23 +42,22 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "GaussOptProcPass";
     }
 
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
     virtual void setUniforms();
     virtual void getUniforms();
-    virtual const char *getFragmentShaderSource();
-    virtual const char *getVertexShaderSource();
+    virtual const char* getFragmentShaderSource();
+    virtual const char* getVertexShaderSource();
 
 private:
-
     bool doNorm = false;
     int renderPass; // render pass number. must be 1 or 2
 
-    float pxDx;	// pixel delta value for texture access
-    float pxDy;	// pixel delta value for texture access
+    float pxDx; // pixel delta value for texture access
+    float pxDy; // pixel delta value for texture access
 
     float normConst = 0.005;
 
@@ -70,6 +69,5 @@ private:
     std::string vshaderGaussSrc;
     std::string fshaderGaussSrc;
 };
-
 }
 #endif

--- a/ogles_gpgpu/common/proc/multipass/gauss_pass.cpp
+++ b/ogles_gpgpu/common/proc/multipass/gauss_pass.cpp
@@ -9,16 +9,15 @@
 
 // Modifications: Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../../common_includes.h"
 #include "gauss_pass.h"
+#include "../../common_includes.h"
 
 using namespace ogles_gpgpu;
 
 // #### 7 tap filters ####
 
-// *INDENT-OFF*
-const char *GaussProcPass::vshaderGauss7Src = OG_TO_STR
-(
+// clang-format off
+const char *GaussProcPass::vshaderGauss7Src = OG_TO_STR(
  attribute vec4 position;
  attribute vec4 inputTextureCoordinate;
 
@@ -49,15 +48,14 @@ const char *GaussProcPass::vshaderGauss7Src = OG_TO_STR
      textureCoordinateP2 = textureCoordinate + texelStep * 2.0;
      textureCoordinateP3 = textureCoordinate + texelStep * 3.0;
  });
-// *INDENT-ON*
+// clang-format on
 
-// *INDENT-OFF*
-const char *GaussProcPass::fshaderGauss7Src = OG_TO_STR
-(
+// clang-format off
+const char *GaussProcPass::fshaderGauss7Src = 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  uniform sampler2D inputImageTexture;
 
  varying vec2 textureCoordinateN3;
@@ -82,7 +80,7 @@ void main()
     gl_FragColor = 0.015625 * (pxL3 + pxR3) + 0.09375 * (pxL2 + pxR2) + 0.234375 * (pxL1 + pxR1) + 0.3125 * pxC;
 }
 );
-// *INDENT-ON*
+// clang-format on
 
 // 1 6 15 20 15 6 1
 // 20+30+12+2 = 64
@@ -91,13 +89,12 @@ void main()
 // 6/64 = 0.09375
 // 1/64 = 0.015625
 
-// *INDENT-OFF*
-const char *GaussProcPass::fshaderGauss7SrcR = OG_TO_STR
-(
+// clang-format off
+const char *GaussProcPass::fshaderGauss7SrcR =
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  uniform sampler2D inputImageTexture;
 
  varying vec2 textureCoordinateN3;
@@ -122,13 +119,12 @@ void main()
     pxC.r = (0.006 * (pxL3 + pxR3) + 0.061 * (pxL2 + pxR2) + 0.242 * (pxL1 + pxR1) + 0.382 * pxC.r);
     gl_FragColor = pxC;
 });
-// *INDENT-ON*
+// clang-format on
 
 // #### 5 tap filters ####
 
-// *INDENT-OFF*
-const char *GaussProcPass::vshaderGauss5Src = OG_TO_STR
-(
+// clang-format off
+const char *GaussProcPass::vshaderGauss5Src = OG_TO_STR(
  attribute vec4 position;
  attribute vec4 inputTextureCoordinate;
 
@@ -155,16 +151,15 @@ const char *GaussProcPass::vshaderGauss5Src = OG_TO_STR
      textureCoordinateP1 = textureCoordinate + texelStep;
      textureCoordinateP2 = textureCoordinate + texelStep * 2.0;
  });
-// *INDENT-ON*
+// clang-format on
 
-// *INDENT-OFF*
-const char *GaussProcPass::fshaderGauss5Src = OG_TO_STR
-(
+// clang-format off
+const char *GaussProcPass::fshaderGauss5Src = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+ OG_TO_STR(precision highp float;)
 #endif
-
+ OG_TO_STR(
  uniform sampler2D inputImageTexture;
 
  varying vec2 textureCoordinateN2;
@@ -185,7 +180,7 @@ const char *GaussProcPass::fshaderGauss5Src = OG_TO_STR
     vec4 result = (0.0625 * (pxL2 + pxR2) + 0.25 * (pxL1 + pxR1) + 0.375 * pxC);
     gl_FragColor = result;
 });
-// *INDENT-ON*
+// clang-format on
 
 // 1 4 6 4 1
 // 1+4+6+4+1 = 16
@@ -193,13 +188,12 @@ const char *GaussProcPass::fshaderGauss5Src = OG_TO_STR
 // 4/16 = 0.25
 // 1/16 = 0.0625
 
-// *INDENT-OFF*
-const char *GaussProcPass::fshaderGauss5SrcR = OG_TO_STR
-(
+// clang-format off
+const char *GaussProcPass::fshaderGauss5SrcR = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  uniform sampler2D inputImageTexture;
 
  varying vec2 textureCoordinateN2;
@@ -220,9 +214,9 @@ const char *GaussProcPass::fshaderGauss5SrcR = OG_TO_STR
     pxC.r = (0.0625 * (pxL2 + pxR2) + 0.25 * (pxL1 + pxR1) + 0.375 * pxC.r);
     gl_FragColor = pxC;
 });
-// *INDENT-ON*
+// clang-format on
 
-void GaussProcPass::filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target) {
+void GaussProcPass::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target) {
     // create shader object
     ProcBase::createShader(vShaderSrc, fShaderSrc, target);
 
@@ -252,8 +246,8 @@ void GaussProcPass::getUniforms() {
     shParamUInputTex = shader->getParam(UNIF, "inputImageTexture");
 }
 
-const char *GaussProcPass::getFragmentShaderSource() {
-    switch(kernel) {
+const char* GaussProcPass::getFragmentShaderSource() {
+    switch (kernel) {
     case k5Tap:
         return doR ? fshaderGauss5SrcR : fshaderGauss5Src;
     case k7Tap:
@@ -263,8 +257,8 @@ const char *GaussProcPass::getFragmentShaderSource() {
     }
 }
 
-const char *GaussProcPass::getVertexShaderSource() {
-    switch(kernel) {
+const char* GaussProcPass::getVertexShaderSource() {
+    switch (kernel) {
     case k5Tap:
         return vshaderGauss5Src;
     case k7Tap:

--- a/ogles_gpgpu/common/proc/multipass/gauss_pass.h
+++ b/ogles_gpgpu/common/proc/multipass/gauss_pass.h
@@ -27,7 +27,6 @@ namespace ogles_gpgpu {
  */
 class GaussProcPass : public FilterProcBase {
 public:
-
     enum KernelSize {
         k5Tap,
         k7Tap
@@ -36,7 +35,7 @@ public:
     /**
      * Construct as render pass <pass> (1 or 2).
      */
-    GaussProcPass(int pass, KernelSize kernel=k5Tap, bool doR=false)
+    GaussProcPass(int pass, KernelSize kernel = k5Tap, bool doR = false)
         : FilterProcBase()
         , renderPass(pass)
         , kernel(kernel)
@@ -49,15 +48,15 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "GaussProcPass";
     }
 
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
     virtual void setUniforms();
     virtual void getUniforms();
-    virtual const char *getFragmentShaderSource();
-    virtual const char *getVertexShaderSource();
+    virtual const char* getFragmentShaderSource();
+    virtual const char* getVertexShaderSource();
 
 private:
     int renderPass; // render pass number. must be 1 or 2
@@ -69,14 +68,13 @@ private:
     GLint texelWidthUniform, texelHeightUniform;
     float texelWidth, texelHeight;
 
-    static const char *vshaderGauss7Src;
-    static const char *fshaderGauss7Src;  // fragment shader source for gaussian smoothing for both passes
-    static const char *fshaderGauss7SrcR; // shader for R channel
+    static const char* vshaderGauss7Src;
+    static const char* fshaderGauss7Src; // fragment shader source for gaussian smoothing for both passes
+    static const char* fshaderGauss7SrcR; // shader for R channel
 
-    static const char *vshaderGauss5Src;
-    static const char *fshaderGauss5Src;  // fragment shader source for gaussian smoothing for both passes
-    static const char *fshaderGauss5SrcR; // shader for R channel
+    static const char* vshaderGauss5Src;
+    static const char* fshaderGauss5Src; // fragment shader source for gaussian smoothing for both passes
+    static const char* fshaderGauss5SrcR; // shader for R channel
 };
-
 }
 #endif

--- a/ogles_gpgpu/common/proc/multipass/local_norm_pass.cpp
+++ b/ogles_gpgpu/common/proc/multipass/local_norm_pass.cpp
@@ -6,20 +6,20 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../../common_includes.h"
 #include "local_norm_pass.h"
+#include "../../common_includes.h"
 
 using namespace ogles_gpgpu;
 
-const char *LocalNormPass::fshaderLocalNormPass1Src = OG_TO_STR
-        (
+// clang-format off
+const char *LocalNormPass::fshaderLocalNormPass1Src = 
 #if defined(OGLES_GPGPU_OPENGLES)
-            precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
-            uniform sampler2D uInputTex;
-            uniform float uPxD;
-            varying vec2 vTexCoord;
+OG_TO_STR(
+uniform sampler2D uInputTex;
+uniform float uPxD;
+varying vec2 vTexCoord;
 // 7x1 Gauss kernel
 void main() {
     vec4 pxC  = texture2D(uInputTex, vTexCoord);
@@ -33,17 +33,18 @@ void main() {
 
     gl_FragColor = vec4(pxC.rgb, val); // {r,g,b,r_mean}
 });
+// clang-format on
 
-const char *LocalNormPass::fshaderLocalNormPass2Src = OG_TO_STR
-        (
+// clang-format off
+const char *LocalNormPass::fshaderLocalNormPass2Src =
 #if defined(OGLES_GPGPU_OPENGLES)
-            precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
-            uniform sampler2D uInputTex;
-            uniform float uPxD;
-            uniform float normConst;
-            varying vec2 vTexCoord;
+OG_TO_STR(
+uniform sampler2D uInputTex;
+uniform float uPxD;
+uniform float normConst;
+varying vec2 vTexCoord;
 // 7x1 Gauss kernel
 void main() {
     vec4 pxC  = texture2D(uInputTex, vTexCoord);
@@ -59,6 +60,7 @@ void main() {
 
     gl_FragColor = vec4(clamp(0.5 * rNorm, 0.0, 1.0), pxC.g, pxC.r, val); // {r_norm,g,r,r_mean}
 });
+// clang-format on
 
 int LocalNormPass::init(int inW, int inH, unsigned int order, bool prepareForExternalInput) {
     OG_LOGINF(getProcName(), "render pass %d", renderPass);
@@ -74,12 +76,12 @@ int LocalNormPass::init(int inW, int inH, unsigned int order, bool prepareForExt
     pxDy = 1.0f / (float)outFrameH;
 
     // get necessary fragment shader source
-    const char *shSrc = renderPass == 1 ? fshaderLocalNormPass1Src : fshaderLocalNormPass2Src;
+    const char* shSrc = renderPass == 1 ? fshaderLocalNormPass1Src : fshaderLocalNormPass2Src;
 
     // FilterProcBase init - create shaders, get shader params, set buffers for OpenGL
     filterInit(vshaderDefault, shSrc, RenderOrientationDiagonal);
 
-    if(renderPass == 2) {
+    if (renderPass == 2) {
         shParamUNormConst = shader->getParam(UNIF, "normConst");
     }
 
@@ -93,7 +95,7 @@ void LocalNormPass::createFBOTex(bool genMipmap) {
     assert(fbo);
 
     if (renderPass == 1) {
-        fbo->createAttachedTex(outFrameH, outFrameW, genMipmap);   // swapped
+        fbo->createAttachedTex(outFrameH, outFrameW, genMipmap); // swapped
     } else {
         fbo->createAttachedTex(outFrameW, outFrameH, genMipmap);
     }
@@ -108,9 +110,9 @@ int LocalNormPass::render(int position) {
 
     filterRenderPrepare();
 
-    glUniform1f(shParamUPxD, renderPass == 1 ? pxDy : pxDx);	// texture pixel delta values
-    if(renderPass == 2) {
-        glUniform1f (shParamUNormConst, normConst);
+    glUniform1f(shParamUPxD, renderPass == 1 ? pxDy : pxDx); // texture pixel delta values
+    if (renderPass == 2) {
+        glUniform1f(shParamUNormConst, normConst);
     }
 
     Tools::checkGLErr(getProcName(), "render prepare");
@@ -119,7 +121,7 @@ int LocalNormPass::render(int position) {
     Tools::checkGLErr(getProcName(), "render set coords");
 
     filterRenderDraw();
-    Tools::checkGLErr(getProcName(),  "render draw");
+    Tools::checkGLErr(getProcName(), "render draw");
 
     filterRenderCleanup();
     Tools::checkGLErr(getProcName(), "render cleanup");

--- a/ogles_gpgpu/common/proc/multipass/local_norm_pass.h
+++ b/ogles_gpgpu/common/proc/multipass/local_norm_pass.h
@@ -34,7 +34,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "LocalNormPass";
     }
 
@@ -47,7 +47,7 @@ public:
     /**
      * Render the output.
      */
-    virtual int render(int position=0);
+    virtual int render(int position = 0);
 
     /**
      * Create a texture that is attached to the FBO and will contain the processing result.
@@ -59,16 +59,15 @@ public:
 private:
     int renderPass; // render pass number. must be 1 or 2
 
-    GLint shParamUPxD;		// pixel delta values for texture lookup in the fragment shader. only used for adapt. thresholding
-    float pxDx;	// pixel delta value for texture access
-    float pxDy;	// pixel delta value for texture access
+    GLint shParamUPxD; // pixel delta values for texture lookup in the fragment shader. only used for adapt. thresholding
+    float pxDx; // pixel delta value for texture access
+    float pxDy; // pixel delta value for texture access
 
     GLint shParamUNormConst;
     float normConst = 0.00005; // normalization constant
 
-    static const char *fshaderLocalNormPass1Src;  // fragment shader source for gaussian smoothing for both passes
-    static const char *fshaderLocalNormPass2Src;  // fragment shader source for gaussian smoothing for both passes
+    static const char* fshaderLocalNormPass1Src; // fragment shader source for gaussian smoothing for both passes
+    static const char* fshaderLocalNormPass2Src; // fragment shader source for gaussian smoothing for both passes
 };
-
 }
 #endif

--- a/ogles_gpgpu/common/proc/nms.cpp
+++ b/ogles_gpgpu/common/proc/nms.cpp
@@ -6,21 +6,20 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "nms.h"
+#include "../common_includes.h"
 
 #include <regex>
 
 using namespace std;
 using namespace ogles_gpgpu;
 
-// *INDENT-OFF*
-const char *NmsProc::fshaderNmsSrc = OG_TO_STR
-(
+// clang-format off
+const char *NmsProc::fshaderNmsSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision OGLES_GPGPU_HIGHP float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
  uniform sampler2D inputImageTexture;
 
  varying vec2 textureCoordinate;
@@ -65,10 +64,9 @@ precision OGLES_GPGPU_HIGHP float;
 
      gl_FragColor = vec4(finalValue, centerColor.gba); // DO NOT EDIT (see swizzle)
 });
-// *INDENT-ON*
+// clang-format on
 
 NmsProc::NmsProc() {
-
 }
 
 void NmsProc::setUniforms() {
@@ -85,33 +83,33 @@ void NmsProc::getUniforms() {
 void NmsProc::swizzle(int channelIn, int channelOut) {
     std::string new1, new2;
 
-    if(channelOut < 0) {
+    if (channelOut < 0) {
         channelOut = channelIn;
     }
 
     fshaderNmsSwizzleSrc.clear();
     fshaderNmsSwizzleSrc += fshaderNmsSrc; // deep copy
 
-    switch(channelIn) {
+    switch (channelIn) {
     case 0:
-        break;                   // R
+        break; // R
     case 1: {
-        new1 = ".g";    // G
+        new1 = ".g"; // G
         break;
     }
     case 2: {
-        new1 = ".b";    // B
+        new1 = ".b"; // B
         break;
     }
     case 3: {
-        new1 = ".a";    // A
+        new1 = ".a"; // A
         break;
     }
     default:
         assert(false);
     }
 
-    switch(channelOut) {
+    switch (channelOut) {
     case 0:
         break;
     case 1: {
@@ -133,12 +131,12 @@ void NmsProc::swizzle(int channelIn, int channelOut) {
     const std::regex pattern1("\\.r");
     const std::regex pattern2("vec4\\(finalValue, centerColor.gba\\)");
 
-    if(!new1.empty()) {
+    if (!new1.empty()) {
         auto fshader1 = std::regex_replace(fshaderNmsSwizzleSrc, pattern1, new1);
         std::swap(fshader1, fshaderNmsSwizzleSrc);
     }
 
-    if(!new2.empty()) {
+    if (!new2.empty()) {
         auto fshader2 = std::regex_replace(fshaderNmsSwizzleSrc, pattern2, new2);
         std::swap(fshader2, fshaderNmsSwizzleSrc);
     }

--- a/ogles_gpgpu/common/proc/nms.h
+++ b/ogles_gpgpu/common/proc/nms.h
@@ -29,7 +29,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "NmsProc";
     }
 
@@ -47,14 +47,13 @@ public:
         return threshold;
     }
 
-    void swizzle(int channelIn, int channelOut=-1);
+    void swizzle(int channelIn, int channelOut = -1);
 
 private:
-
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderNmsSwizzleSrc.empty() ? fshaderNmsSrc : fshaderNmsSwizzleSrc.c_str();
     }
 
@@ -68,7 +67,7 @@ private:
      */
     virtual void setUniforms();
 
-    static const char *fshaderNmsSrc;   // fragment shader source
+    static const char* fshaderNmsSrc; // fragment shader source
 
     std::string fshaderNmsSwizzleSrc;
 

--- a/ogles_gpgpu/common/proc/pyramid.cpp
+++ b/ogles_gpgpu/common/proc/pyramid.cpp
@@ -6,13 +6,13 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "pyramid.h"
+#include "../common_includes.h"
 
 using namespace std;
 using namespace ogles_gpgpu;
 
-static std::vector<Rect2d> pack(const std::vector<Size2d> &src) {
+static std::vector<Rect2d> pack(const std::vector<Size2d>& src) {
     std::vector<Rect2d> packed;
 
     int x = 0, y = 0;
@@ -20,17 +20,17 @@ static std::vector<Rect2d> pack(const std::vector<Size2d> &src) {
 
     // Decrease going forward:
     int i = 0;
-    for(; (i < src.size()) && !half; i++) {
+    for (; (i < src.size()) && !half; i++) {
         packed.emplace_back(x, y, src[i].width, src[i].height);
         x += src[i].width;
-        if(src[i].height*2 < src[0].height) {
+        if (src[i].height * 2 < src[0].height) {
             half = true;
         }
     }
 
     // Decrease going backward -- now x becomes the right edge
     int t, l, r, b = src[0].height;
-    for(; i < src.size(); i++) {
+    for (; i < src.size(); i++) {
         r = x;
         l = r - src[i].width;
         t = b - src[i].height;
@@ -41,14 +41,14 @@ static std::vector<Rect2d> pack(const std::vector<Size2d> &src) {
     return packed;
 }
 
-static std::vector<Rect2d> reduce(const Size2d &src, int levels) {
+static std::vector<Rect2d> reduce(const Size2d& src, int levels) {
     std::vector<Rect2d> packed;
 
     int x = 0, y = 0, w = src.width, h = src.height;
-    for(int i = 0; i < levels; i++) {
+    for (int i = 0; i < levels; i++) {
         packed.emplace_back(x, y, w, h);
 
-        if(i % 2) {
+        if (i % 2) {
             y += h;
         } else {
             x += w;
@@ -61,20 +61,19 @@ static std::vector<Rect2d> reduce(const Size2d &src, int levels) {
     return packed;
 }
 
-
-PyramidProc::PyramidProc(int levels) : m_levels(levels) {
-
+PyramidProc::PyramidProc(int levels)
+    : m_levels(levels) {
 }
 
-PyramidProc::PyramidProc(const std::vector<Size2d> &scales) : m_scales(scales) {
-
+PyramidProc::PyramidProc(const std::vector<Size2d>& scales)
+    : m_scales(scales) {
 }
 
 void PyramidProc::setOutputSize(float scaleFactor) {
     // noop
 }
 
-void PyramidProc::setScales(const std::vector<Size2d> &scales) {
+void PyramidProc::setScales(const std::vector<Size2d>& scales) {
     m_crops = pack(scales);
 }
 
@@ -83,7 +82,7 @@ void PyramidProc::setLevels(int levels) {
     m_levels = levels;
 }
 
-const std::vector<Rect2d> & PyramidProc::getLevelCrops() const {
+const std::vector<Rect2d>& PyramidProc::getLevelCrops() const {
     return m_crops;
 }
 
@@ -100,9 +99,9 @@ int PyramidProc::PyramidProc::render(int position) {
 
     // Set a constant background color
     glClear(GL_COLOR_BUFFER_BIT);
-    glClearColor(0,0,0,1);
+    glClearColor(0, 0, 0, 1);
 
-    for(auto &c : m_crops) {
+    for (auto& c : m_crops) {
         glViewport(c.x, c.y, c.width, c.height);
         filterRenderDraw();
     }
@@ -114,24 +113,20 @@ int PyramidProc::PyramidProc::render(int position) {
     return 0;
 }
 
-
 int PyramidProc::init(int inW, int inH, unsigned int order, bool prepareForExternalInput) {
     int width = 0, height = 0;
-    if(m_scales.size()) {
+    if (m_scales.size()) {
         m_crops = pack(m_scales);
-        for(const auto &c : m_crops) {
+        for (const auto& c : m_crops) {
             width = std::max(width, c.x + c.width);
             height = std::max(height, c.y + c.height);
         }
     } else {
-        m_crops = reduce({inW, inH}, m_levels);
+        m_crops = reduce({ inW, inH }, m_levels);
         width = inW * 3 / 2;
         height = inH;
-
     }
 
     FilterProcBase::setOutputSize(width, height);
     return FilterProcBase::init(inW, inH, order, prepareForExternalInput);
 }
-
-

--- a/ogles_gpgpu/common/proc/pyramid.h
+++ b/ogles_gpgpu/common/proc/pyramid.h
@@ -25,7 +25,6 @@ namespace ogles_gpgpu {
  */
 class PyramidProc : public TransformProc {
 public:
-
     /**
      * Constructor for pyramid.
      */
@@ -34,17 +33,17 @@ public:
     /**
      * Constructor for multiscale.
      */
-    PyramidProc(const std::vector<Size2d> &scales);
+    PyramidProc(const std::vector<Size2d>& scales);
 
     /**
      * Render a flat pyramid
      */
-    virtual int render(int position=0);
+    virtual int render(int position = 0);
 
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "PyramidProc";
     }
 
@@ -56,7 +55,7 @@ public:
     /**
      * Preset output scales
      */
-    void setScales(const std::vector<Size2d> &scales);
+    void setScales(const std::vector<Size2d>& scales);
 
     /**
      * Set the # of pyramid levels.
@@ -66,10 +65,9 @@ public:
     /**
      * Get level crops.
      */
-    const std::vector<Rect2d> & getLevelCrops() const;
+    const std::vector<Rect2d>& getLevelCrops() const;
 
 private:
-
     virtual void setOutputSize(float scaleFactor);
 
     std::vector<Size2d> m_scales;
@@ -77,7 +75,6 @@ private:
     int m_levels = 4;
 
     std::vector<Rect2d> m_crops;
-
 };
 }
 

--- a/ogles_gpgpu/common/proc/remap.cpp
+++ b/ogles_gpgpu/common/proc/remap.cpp
@@ -12,7 +12,7 @@
 
 using namespace ogles_gpgpu;
 
-// *INDENT-OFF*
+// clang-format off
 const char *RemapProc::vshaderRemapSrc = OG_TO_STR
 (
     attribute vec4 position;
@@ -24,14 +24,14 @@ const char *RemapProc::vshaderRemapSrc = OG_TO_STR
         textureCoordinate = inputTextureCoordinate.xy;
     }
 );
-// *INDENT-ON*
+// clang-format on
 
-// *INDENT-OFF*
-const char *RemapProc::fshaderRemapSrc = OG_TO_STR
-(
+// clang-format off
+const char *RemapProc::fshaderRemapSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
+OG_TO_STR(    
  varying vec2 textureCoordinate;
  uniform sampler2D inputImageTexture;  // IMAGE
  uniform sampler2D inputImageTexture2; // FLOW
@@ -46,11 +46,11 @@ const char *RemapProc::fshaderRemapSrc = OG_TO_STR
      vec4 centerIntensity = texture2D(inputImageTexture, textureCoordinate + (delta * offset));
      gl_FragColor = centerIntensity;
  });
-// *INDENT-ON*
+// clang-format on
 
 RemapProc::RemapProc() {}
 
-void RemapProc::filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target) {
+void RemapProc::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target) {
     // create shader object
     ProcBase::createShader(vShaderSrc, fShaderSrc, target);
 
@@ -64,12 +64,10 @@ void RemapProc::filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc
 }
 
 void RemapProc::getUniforms() {
-
 }
 
 void RemapProc::setUniforms() {
     // Set texel width/height uniforms:
-    glUniform1f(texelWidthUniform, (1.0f/ float(outFrameW)));
-    glUniform1f(texelHeightUniform, (1.0f/ float(outFrameH)));
+    glUniform1f(texelWidthUniform, (1.0f / float(outFrameW)));
+    glUniform1f(texelHeightUniform, (1.0f / float(outFrameH)));
 }
-

--- a/ogles_gpgpu/common/proc/remap.h
+++ b/ogles_gpgpu/common/proc/remap.h
@@ -18,27 +18,27 @@ namespace ogles_gpgpu {
 class RemapProc : public TwoInputProc {
 public:
     RemapProc();
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "RemapProc";
     }
-private:
 
-    void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+private:
+    void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
     void getUniforms();
     void setUniforms();
 
     GLint texelWidthUniform;
     GLint texelHeightUniform;
 
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderRemapSrc;
     }
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderRemapSrc;
     }
 
-    static const char *vshaderRemapSrc;
-    static const char *fshaderRemapSrc;
+    static const char* vshaderRemapSrc;
+    static const char* fshaderRemapSrc;
 };
 }
 

--- a/ogles_gpgpu/common/proc/rgb2hsv.cpp
+++ b/ogles_gpgpu/common/proc/rgb2hsv.cpp
@@ -10,14 +10,13 @@
 
 #include "rgb2hsv.h"
 
-// *INDENT-OFF*
+// clang-format off
 BEGIN_OGLES_GPGPU
-const char * Rgb2HsvProc::fshaderRgb2HsvSrc = OG_TO_STR
-(
+const char * Rgb2HsvProc::fshaderRgb2HsvSrc = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  vec3 rgb2hsv(vec3 c)
  {
     vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
@@ -31,11 +30,11 @@ const char * Rgb2HsvProc::fshaderRgb2HsvSrc = OG_TO_STR
 
  varying vec2 vTexCoord;
  uniform sampler2D uInputTex;
- uniform float gain;
  void main()
  {
      vec4 val = texture2D(uInputTex, vTexCoord);
      gl_FragColor = vec4(rgb2hsv(val.rgb), 1.0);
  });
+
 END_OGLES_GPGPU
-// *INDENT-ON*
+// clang-format on

--- a/ogles_gpgpu/common/proc/rgb2hsv.h
+++ b/ogles_gpgpu/common/proc/rgb2hsv.h
@@ -9,31 +9,24 @@
 #ifndef OGLES_GPGPU_COMMON_RGB2HSV_PROC
 #define OGLES_GPGPU_COMMON_RGB2HSV_PROC
 
+#include "../common_includes.h"
 #include "ogles_gpgpu/common/proc/base/filterprocbase.h"
 
 BEGIN_OGLES_GPGPU
 
 class Rgb2HsvProc : public ogles_gpgpu::FilterProcBase {
 public:
-    Rgb2HsvProc(float gain=1.f) : gain(gain) {}
-    virtual const char *getProcName() {
+    Rgb2HsvProc() {}
+    virtual const char* getProcName() {
         return "Rgb2HsvProc";
     }
+
 private:
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderRgb2HsvSrc;
     }
-    virtual void getUniforms() {
-        shParamUGain = shader->getParam(UNIF, "gain");
-    }
-    virtual void setUniforms() {
-        glUniform1f(shParamUGain, gain);
-    }
-    static const char *fshaderRgb2HsvSrc; // fragment shader source
-    float gain = 1.f;
-    GLint shParamUGain;
+
+    static const char* fshaderRgb2HsvSrc; // fragment shader source
 };
-
 END_OGLES_GPGPU
-
 #endif

--- a/ogles_gpgpu/common/proc/shitomasi.cpp
+++ b/ogles_gpgpu/common/proc/shitomasi.cpp
@@ -6,21 +6,19 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "shitomasi.h"
+#include "../common_includes.h"
 
 using namespace std;
 using namespace ogles_gpgpu;
 
-
-
-// *INDENT-OFF*
-const char *ShiTomasiProc::fshaderShiTomasiSrc = OG_TO_STR(
+// clang-format off
+const char *ShiTomasiProc::fshaderShiTomasiSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
 varying vec2 textureCoordinate;
 
 uniform sampler2D inputImageTexture;
@@ -38,15 +36,13 @@ void main()
 
     gl_FragColor = vec4(vec3(cornerness) * sensitivity, 1.0);
 });
-// *INDENT-ON*
+// clang-format on
 
 ShiTomasiProc::ShiTomasiProc() {
-
 }
 
-
 // TODO: We need to override this if we are using the GPUImage shaders
-void ShiTomasiProc::filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target) {
+void ShiTomasiProc::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target) {
     // create shader object
     ProcBase::createShader(vShaderSrc, fShaderSrc, target);
 
@@ -59,10 +55,10 @@ void ShiTomasiProc::filterShaderSetup(const char *vShaderSrc, const char *fShade
 void ShiTomasiProc::getUniforms() {
     FilterProcBase::getUniforms();
     shParamUInputTex = shader->getParam(UNIF, "inputImageTexture");
-    shParamUInputSensitivity =  shader->getParam(UNIF, "sensitivity");
+    shParamUInputSensitivity = shader->getParam(UNIF, "sensitivity");
 }
 
 void ShiTomasiProc::setUniforms() {
     FilterProcBase::setUniforms();
-    glUniform1f (shParamUInputSensitivity, sensitivity);   // set additional uniforms
+    glUniform1f(shParamUInputSensitivity, sensitivity); // set additional uniforms
 }

--- a/ogles_gpgpu/common/proc/shitomasi.h
+++ b/ogles_gpgpu/common/proc/shitomasi.h
@@ -31,7 +31,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "ShiTomasiProc";
     }
 
@@ -50,7 +50,6 @@ public:
     }
 
 private:
-
     /**
      * Set additional uniforms.
      */
@@ -62,23 +61,23 @@ private:
     virtual void getUniforms();
 
     // TODO: we currently need to override the filterShaderSetup to parse uniforms from the GPUImage
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
 
     /**
      * Get the vertex shader source.
      */
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderGPUImage;
     }
 
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderShiTomasiSrc;
     }
 
-    static const char *fshaderShiTomasiSrc;         // fragment shader source
+    static const char* fshaderShiTomasiSrc; // fragment shader source
 
     GLuint shParamUInputSensitivity = 0;
 

--- a/ogles_gpgpu/common/proc/tensor.cpp
+++ b/ogles_gpgpu/common/proc/tensor.cpp
@@ -6,21 +6,21 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "tensor.h"
+#include "../common_includes.h"
 
 using namespace std;
 using namespace ogles_gpgpu;
 
 // Source: GPUImageXYDerivativeFilter.m
 
-// *INDENT-OFF*
-const char *TensorProc::fshaderTensorSrc = OG_TO_STR(
+// clang-format off
+const char *TensorProc::fshaderTensorSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
+OG_TO_STR(
 varying vec2 textureCoordinate;
 varying vec2 leftTextureCoordinate;
 varying vec2 rightTextureCoordinate;
@@ -64,10 +64,9 @@ void main()
     // is useful for optical flow.
     gl_FragColor = vec4(xx, yy, (xy + 1.0) / 2.0, centerIntensity);
 });
-// *INDENT-ON*
+// clang-format on
 
 TensorProc::TensorProc() {
-
 }
 
 void TensorProc::setUniforms() {
@@ -80,4 +79,3 @@ void TensorProc::getUniforms() {
     shParamUInputTex = shader->getParam(UNIF, "inputImageTexture");
     shParamUEdgeStrength = shader->getParam(UNIF, "edgeStrength");
 }
-

--- a/ogles_gpgpu/common/proc/tensor.h
+++ b/ogles_gpgpu/common/proc/tensor.h
@@ -29,7 +29,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "TensorProc";
     }
 
@@ -42,11 +42,10 @@ public:
     }
 
 private:
-
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderTensorSrc;
     }
 
@@ -64,7 +63,7 @@ private:
 
     GLuint shParamUEdgeStrength = 0;
 
-    static const char *fshaderTensorSrc;   // fragment shader source
+    static const char* fshaderTensorSrc; // fragment shader source
 };
 }
 

--- a/ogles_gpgpu/common/proc/three.cpp
+++ b/ogles_gpgpu/common/proc/three.cpp
@@ -11,13 +11,13 @@
 using namespace std;
 using namespace ogles_gpgpu;
 
-// *INDENT-OFF*
-const char *ThreeInputProc::vshaderThreeInputSrc = OG_TO_STR(
+// clang-format off
+const char *ThreeInputProc::vshaderThreeInputSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  attribute vec4 position;
  attribute vec4 inputTextureCoordinate;
 
@@ -29,12 +29,12 @@ precision mediump float;
      textureCoordinate = inputTextureCoordinate.xy;
  });
 
-const char *ThreeInputProc::fshaderThreeInputSrc = OG_TO_STR(
+const char *ThreeInputProc::fshaderThreeInputSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
 
  uniform sampler2D inputImageTexture;
@@ -48,16 +48,15 @@ precision mediump float;
      vec4 textureColor3 = texture2D(inputImageTexture3, textureCoordinate);
 	 gl_FragColor = vec4(textureColor.rgb - textureColor2.rgb, textureColor.a);
 });
-// *INDENT-ON*
+// clang-format on
 
 ThreeInputProc::ThreeInputProc() {
-
 }
 
 int ThreeInputProc::render(int position) {
     int result = 1;
 
-    switch(position) {
+    switch (position) {
     case 0:
         hasTex1 = true;
         break;
@@ -71,7 +70,7 @@ int ThreeInputProc::render(int position) {
         assert(false);
     }
 
-    if((hasTex1 || !waitForFirstTexture) && (hasTex2 || !waitForSecondTexture) && (hasTex3 || !waitForThirdTexture)) {
+    if ((hasTex1 || !waitForFirstTexture) && (hasTex2 || !waitForSecondTexture) && (hasTex3 || !waitForThirdTexture)) {
         result = FilterProcBase::render(position);
         hasTex1 = hasTex2 = hasTex3 = false;
     }
@@ -83,7 +82,7 @@ int ThreeInputProc::render(int position) {
  */
 
 void ThreeInputProc::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int position) {
-    switch(position) {
+    switch (position) {
     case 0:
         FilterProcBase::useTexture(id, useTexUnit, target, position);
         break;
@@ -136,7 +135,7 @@ void ThreeInputProc::filterRenderPrepare() {
     glUniform1i(shParamUInputTex3, texUnit3);
 }
 
-void ThreeInputProc::filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target) {
+void ThreeInputProc::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target) {
     // create shader object
     FilterProcBase::createShader(vShaderSrc, fShaderSrc, target);
 
@@ -158,5 +157,3 @@ void ThreeInputProc::getUniforms() {
 void ThreeInputProc::setUniforms() {
     FilterProcBase::setUniforms();
 }
-
-

--- a/ogles_gpgpu/common/proc/three.h
+++ b/ogles_gpgpu/common/proc/three.h
@@ -26,7 +26,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "ThreeInputProc";
     }
 
@@ -48,23 +48,22 @@ public:
         waitForThirdTexture = flag;
     }
 
-    virtual int render(int position=0);
+    virtual int render(int position = 0);
 
 protected:
-
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
 
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderThreeInputSrc;
     }
 
     /**
      * Get the vertex shader source.
      */
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderThreeInputSrc;
     }
 
@@ -89,19 +88,19 @@ protected:
     bool hasTex2 = false;
     bool waitForSecondTexture = true;
     GLint shParamUInputTex2;
-    GLuint texId2;       // input texture id
-    GLuint texUnit2;     // input texture unit (glActiveTexture())
-    GLenum texTarget2;   // input texture target
+    GLuint texId2; // input texture id
+    GLuint texUnit2; // input texture unit (glActiveTexture())
+    GLenum texTarget2; // input texture target
 
     bool hasTex3 = false;
     bool waitForThirdTexture = true;
     GLint shParamUInputTex3;
-    GLuint texId3;       // input texture id
-    GLuint texUnit3;     // input texture unit (glActiveTexture())
-    GLenum texTarget3;   // input texture target
+    GLuint texId3; // input texture id
+    GLuint texUnit3; // input texture unit (glActiveTexture())
+    GLenum texTarget3; // input texture target
 
-    static const char *fshaderThreeInputSrc; // fragment shader source
-    static const char *vshaderThreeInputSrc; // vertex shader source
+    static const char* fshaderThreeInputSrc; // fragment shader source
+    static const char* vshaderThreeInputSrc; // vertex shader source
 };
 }
 

--- a/ogles_gpgpu/common/proc/thresh.cpp
+++ b/ogles_gpgpu/common/proc/thresh.cpp
@@ -9,29 +9,31 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "thresh.h"
+#include "../common_includes.h"
 
 using namespace std;
 using namespace ogles_gpgpu;
 
 // Simple thresholding fragment shader
 // Requires a grayscale image as input!
-const char *ThreshProc::fshaderSimpleThreshSrc = OG_TO_STR(
+
+// clang-format off
+const char *ThreshProc::fshaderSimpleThreshSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-            precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
-            varying vec2 vTexCoord;
-            uniform float uThresh;
-            uniform sampler2D uInputTex;
+OG_TO_STR(
+varying vec2 vTexCoord;
+uniform float uThresh;
+uniform sampler2D uInputTex;
 void main() {
     float gray = texture2D(uInputTex, vTexCoord).r;
     float bin = step(uThresh, gray);
     gl_FragColor = vec4(bin, bin, bin, 1.0);
-}
-        );
+});
+// clang-format on
 
 ThreshProc::ThreshProc() {
     // set defaults
@@ -61,7 +63,7 @@ int ThreshProc::render(int position) {
 
     filterRenderPrepare();
 
-    glUniform1f(shParamUThresh, threshVal);	// thresholding value for simple thresholding
+    glUniform1f(shParamUThresh, threshVal); // thresholding value for simple thresholding
 
     Tools::checkGLErr("ThreshProc", "render prepare");
 

--- a/ogles_gpgpu/common/proc/thresh.h
+++ b/ogles_gpgpu/common/proc/thresh.h
@@ -35,7 +35,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "ThreshProc";
     }
 
@@ -43,7 +43,7 @@ public:
      * Set threshold as 8 bit value [0..255] <v> for simple thresholding.
      */
     void setThreshVal8Bit(int v) {
-        threshVal = (float)v  / 255.0f;
+        threshVal = (float)v / 255.0f;
     }
 
     /**
@@ -69,14 +69,14 @@ public:
     /**
      * Render the output.
      */
-    virtual int render(int position=0);
+    virtual int render(int position = 0);
 
 private:
-    float threshVal;            // thresholding value [0.0 .. 1.0]
+    float threshVal; // thresholding value [0.0 .. 1.0]
 
-    GLint shParamUThresh;	// fixed threshold value
+    GLint shParamUThresh; // fixed threshold value
 
-    static const char *fshaderSimpleThreshSrc;      // fragment shader source for simple thresholding
+    static const char* fshaderSimpleThreshSrc; // fragment shader source for simple thresholding
 };
 }
 

--- a/ogles_gpgpu/common/proc/transform.cpp
+++ b/ogles_gpgpu/common/proc/transform.cpp
@@ -7,15 +7,15 @@
 // Original shader: theagentd/Myomyomyo http://www.java-gaming.org/index.php?topic=35123.0
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "transform.h"
+#include "../common_includes.h"
 
 #include <memory.h>
 
 using namespace std;
 using namespace ogles_gpgpu;
 
-// *INDENT-OFF*
+// clang-format off
 const char *TransformProc::vshaderTransformSrc = OG_TO_STR(
 attribute vec4 aPos;
 attribute vec2 aTexCoord;
@@ -27,15 +27,15 @@ void main()
     vTexCoord = aTexCoord;
 }
 );
-// *INDENT-ON*
+// clang-format on
 
-// *INDENT-OFF*
-const char *TransformProc::fshaderTransformSrc = OG_TO_STR(
+// clang-format off
+const char *TransformProc::fshaderTransformSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
 varying vec2 vTexCoord;
 uniform sampler2D uInputTex;
 void main()
@@ -43,16 +43,16 @@ void main()
     gl_FragColor = vec4(texture2D(uInputTex, vTexCoord).rgba);
 }
 );
-// *INDENT-ON*
+// clang-format on
 
-// *INDENT-OFF*
-const char *TransformProc::fshaderTransformBicubicSrc = OG_TO_STR(
+// clang-format off
+const char *TransformProc::fshaderTransformBicubicSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
-
-vec4 cubic(OGLES_GPGPU_HIGHP float v)
+OG_TO_STR(
+vec4 cubic(float v)
 {
     vec4 n = vec4(1.0, 2.0, 3.0, 4.0) - v;
     vec4 s = n * n * n;
@@ -64,7 +64,7 @@ vec4 cubic(OGLES_GPGPU_HIGHP float v)
     return result;
 }
 
-vec4 textureBicubic(sampler2D sampler, OGLES_GPGPU_HIGHP vec2 texCoords, OGLES_GPGPU_HIGHP vec2 texSize)
+vec4 textureBicubic(sampler2D sampler, vec2 texCoords, vec2 texSize)
 {
     vec2 invTexSize = 1.0 / texSize;
 
@@ -103,28 +103,27 @@ void main()
    gl_FragColor = textureBicubic(uInputTex, vTexCoord, texSize);
 }
 );
-// *INDENT-ON*
+// clang-format on
 
 TransformProc::TransformProc() {
     memset(transformMatrix.data, 0, sizeof(transformMatrix.data));
-    for(int i = 0; i < 4; i++) {
+    for (int i = 0; i < 4; i++) {
         transformMatrix.data[i][i] = 1;
     }
 }
 
-
-const char *TransformProc::getFragmentShaderSource() {
+const char* TransformProc::getFragmentShaderSource() {
     return (interpolation == BILINEAR) ? fshaderTransformSrc : fshaderTransformBicubicSrc;
 }
 
-const char *TransformProc::getVertexShaderSource() {
+const char* TransformProc::getVertexShaderSource() {
     return vshaderTransformSrc;
 }
 
 void TransformProc::setUniforms() {
     FilterProcBase::setUniforms();
     glUniformMatrix4fv(shParamUTransform, 1, 0, &transformMatrix.data[0][0]);
-    if(interpolation == BICUBIC) {
+    if (interpolation == BICUBIC) {
         glUniform2f(shParamUTransformSize, inFrameW, inFrameH);
     }
 }
@@ -132,12 +131,11 @@ void TransformProc::setUniforms() {
 void TransformProc::getUniforms() {
     FilterProcBase::getUniforms();
     shParamUTransform = shader->getParam(UNIF, "transformMatrix");
-    if(interpolation == BICUBIC) {
+    if (interpolation == BICUBIC) {
         shParamUTransformSize = shader->getParam(UNIF, "texSize");
     }
 }
 
-void TransformProc::setTransformMatrix(const Mat44f &matrix) {
+void TransformProc::setTransformMatrix(const Mat44f& matrix) {
     transformMatrix = matrix;
 }
-

--- a/ogles_gpgpu/common/proc/transform.h
+++ b/ogles_gpgpu/common/proc/transform.h
@@ -23,7 +23,6 @@ namespace ogles_gpgpu {
  */
 class TransformProc : public FilterProcBase {
 public:
-
     enum Interpolation {
         BILINEAR,
         BICUBIC
@@ -37,19 +36,19 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "TransformProc";
     }
 
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource();
+    virtual const char* getFragmentShaderSource();
 
     /**
      * Get the vertex shader source.
      */
-    virtual const char *getVertexShaderSource();
+    virtual const char* getVertexShaderSource();
 
     /**
      * Set additional uniforms.
@@ -64,14 +63,14 @@ public:
     /**
      * Get the transformation matrix.
      */
-    const Mat44f & getTransformMatrix() const {
+    const Mat44f& getTransformMatrix() const {
         return transformMatrix;
     }
 
     /**
      * Set the transformation matrix.
      */
-    void setTransformMatrix(const Mat44f & matrix);
+    void setTransformMatrix(const Mat44f& matrix);
 
     /**
      * Set interpolation mode.
@@ -88,17 +87,16 @@ public:
     }
 
 protected:
-
-    static const char *vshaderTransformSrc;   // fragment shader source
-    static const char *fshaderTransformSrc;   // fragment shader source
-    static const char *fshaderTransformBicubicSrc; // bicubic shader
+    static const char* vshaderTransformSrc; // fragment shader source
+    static const char* fshaderTransformSrc; // fragment shader source
+    static const char* fshaderTransformBicubicSrc; // bicubic shader
 
     Interpolation interpolation = BILINEAR;
 
-    GLint shParamUTransform;        // shader uniform transformation matrix
-    Mat44f transformMatrix;         // currently set weighted channel grayscale conversion vector
+    GLint shParamUTransform; // shader uniform transformation matrix
+    Mat44f transformMatrix; // currently set weighted channel grayscale conversion vector
 
-    GLint shParamUTransformSize=0;  // texture size (for bicubic warp)
+    GLint shParamUTransformSize = 0; // texture size (for bicubic warp)
 };
 }
 

--- a/ogles_gpgpu/common/proc/two.cpp
+++ b/ogles_gpgpu/common/proc/two.cpp
@@ -6,19 +6,19 @@
 
 // Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "two.h"
+#include "../common_includes.h"
 
 using namespace std;
 using namespace ogles_gpgpu;
 
-// *INDENT-OFF*
-const char *TwoInputProc::vshaderTwoInputSrc = OG_TO_STR(
+// clang-format off
+const char *TwoInputProc::vshaderTwoInputSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  attribute vec4 position;
  attribute vec4 inputTextureCoordinate;
 
@@ -29,15 +29,15 @@ precision mediump float;
      gl_Position = position;
      textureCoordinate = inputTextureCoordinate.xy;
  });
-// *INDENT-ON*
+// clang-format on
 
-// *INDENT-OFF*
-const char *TwoInputProc::fshaderTwoInputSrc = OG_TO_STR(
+// clang-format off
+const char *TwoInputProc::fshaderTwoInputSrc = 
 
 #if defined(OGLES_GPGPU_OPENGLES)
-precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
 
  uniform sampler2D inputImageTexture;
@@ -49,16 +49,15 @@ precision mediump float;
 	 vec4 textureColor2 = texture2D(inputImageTexture2, textureCoordinate);
 	 gl_FragColor = vec4(textureColor.rgb - textureColor2.rgb, textureColor.a);
 });
-// *INDENT-ON*
+// clang-format on
 
 TwoInputProc::TwoInputProc() {
-
 }
 
 int TwoInputProc::render(int position) {
     int result = 1;
 
-    switch(position) {
+    switch (position) {
     case 0:
         hasTex1 = true;
         break;
@@ -69,7 +68,7 @@ int TwoInputProc::render(int position) {
         assert(false);
     }
 
-    if(hasTex1 && (hasTex2 || !waitForSecondTexture)) {
+    if (hasTex1 && (hasTex2 || !waitForSecondTexture)) {
         result = FilterProcBase::render(position);
         hasTex1 = hasTex2 = false;
     }
@@ -81,7 +80,7 @@ int TwoInputProc::render(int position) {
  */
 
 void TwoInputProc::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int position) {
-    switch(position) {
+    switch (position) {
     case 0:
         FilterProcBase::useTexture(id, useTexUnit, target, position);
         break;
@@ -119,7 +118,7 @@ void TwoInputProc::filterRenderPrepare() {
     glUniform1i(shParamUInputTex2, texUnit2);
 }
 
-void TwoInputProc::filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target) {
+void TwoInputProc::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target) {
     // create shader object
     FilterProcBase::createShader(vShaderSrc, fShaderSrc, target);
 
@@ -140,5 +139,3 @@ void TwoInputProc::getUniforms() {
 void TwoInputProc::setUniforms() {
     FilterProcBase::setUniforms();
 }
-
-

--- a/ogles_gpgpu/common/proc/two.h
+++ b/ogles_gpgpu/common/proc/two.h
@@ -30,7 +30,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "TwoInputProc";
     }
 
@@ -44,12 +44,11 @@ public:
      */
     virtual void useTexture2(GLuint id, GLuint useTexUnit = 1, GLenum target = GL_TEXTURE_2D);
 
-    virtual int render(int position=0);
+    virtual int render(int position = 0);
 
     void setWaitForSecondTexture(bool flag) {
         waitForSecondTexture = flag;
     }
-
 
     /**
      * Has fist texture
@@ -68,20 +67,19 @@ public:
     }
 
 protected:
-
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
 
     /**
      * Get the fragment shader source.
      */
-    virtual const char *getFragmentShaderSource() {
+    virtual const char* getFragmentShaderSource() {
         return fshaderTwoInputSrc;
     }
 
     /**
      * Get the vertex shader source.
      */
-    virtual const char *getVertexShaderSource() {
+    virtual const char* getVertexShaderSource() {
         return vshaderTwoInputSrc;
     }
 
@@ -104,15 +102,15 @@ protected:
     bool hasTex1 = false;
     bool hasTex2 = false;
 
-    GLuint texId2;       // input texture id
-    GLuint texUnit2;     // input texture unit (glActiveTexture())
-    GLenum texTarget2;   // input texture target
+    GLuint texId2; // input texture id
+    GLuint texUnit2; // input texture unit (glActiveTexture())
+    GLenum texTarget2; // input texture target
 
     GLint shParamUInputTex2;
 
-    static const char *fshaderTwoInputSrc; // fragment shader source
+    static const char* fshaderTwoInputSrc; // fragment shader source
 
-    static const char *vshaderTwoInputSrc; // vertex shader source
+    static const char* vshaderTwoInputSrc; // vertex shader source
 };
 }
 

--- a/ogles_gpgpu/common/proc/video.h
+++ b/ogles_gpgpu/common/proc/video.h
@@ -13,8 +13,8 @@
 #define OGLES_GPGPU_COMMON_VIDEO
 
 #include "../common_includes.h"
-#include "base/procinterface.h"
 #include "base/procbase.h"
+#include "base/procinterface.h"
 #include "yuv2rgb.h"
 
 #include <memory>
@@ -22,23 +22,23 @@
 BEGIN_OGLES_GPGPU
 
 #if __ANDROID__
-#  define DFLT_PIX_FORMAT GL_RGBA
+#define DFLT_PIX_FORMAT GL_RGBA
 #else
-#  define DFLT_PIX_FORMAT GL_BGRA
+#define DFLT_PIX_FORMAT GL_BGRA
 #endif
 
 struct FrameInput {
     FrameInput() {}
-    FrameInput(const Size2d &size, void *pixelBuffer, bool useRawPixels, GLuint inputTexture, GLenum textureFormat)
+    FrameInput(const Size2d& size, void* pixelBuffer, bool useRawPixels, GLuint inputTexture, GLenum textureFormat)
         : size(size)
         , pixelBuffer(pixelBuffer)
         , useRawPixels(useRawPixels)
         , inputTexture(inputTexture)
-        , textureFormat(textureFormat)
-    {}
+        , textureFormat(textureFormat) {
+    }
 
     Size2d size;
-    void *pixelBuffer = nullptr;
+    void* pixelBuffer = nullptr;
     bool useRawPixels = false;
     GLuint inputTexture = 0;
     GLenum textureFormat = 0;
@@ -50,44 +50,42 @@ struct FrameInput {
 
 class VideoSource {
 public:
+    typedef std::function<void(const std::string& tag)> Timer;
 
-    typedef std::function<void(const std::string &tag)> Timer;
+    VideoSource(void* glContext = nullptr);
 
-    VideoSource(void *glContext=nullptr);
+    VideoSource(void* glContext, const Size2d& size, GLenum inputPixFormat);
 
-    VideoSource(void *glContext, const Size2d &size, GLenum inputPixFormat);
-
-    VideoSource(const Size2d &size, GLenum inputPixFormat);
+    VideoSource(const Size2d& size, GLenum inputPixFormat);
 
     virtual ~VideoSource();
 
-    void init(void *glContext);
+    void init(void* glContext);
 
-    void operator()(const FrameInput &frame);
+    void operator()(const FrameInput& frame);
 
-    void operator()(const Size2d &size, void* pixelBuffer, bool useRawPixels, GLuint inputTexture=0, GLenum inputPixFormat=DFLT_PIX_FORMAT);
+    void operator()(const Size2d& size, void* pixelBuffer, bool useRawPixels, GLuint inputTexture = 0, GLenum inputPixFormat = DFLT_PIX_FORMAT);
 
     virtual void preConfig() {}
 
     virtual void postConfig() {}
 
-    void set(ProcInterface *p);
+    void set(ProcInterface* p);
 
-    void setLogger(Timer &timer) {
+    void setLogger(Timer& timer) {
         m_timer = timer;
     }
 
     GLuint getInputTexId();
 
 protected:
-
     Timer m_timer;
 
-    void *glContext = nullptr;
+    void* glContext = nullptr;
 
-    void setInputData(const unsigned char *data);
+    void setInputData(const unsigned char* data);
 
-    void configurePipeline(const Size2d &size, GLenum inputPixFormat);
+    void configurePipeline(const Size2d& size, GLenum inputPixFormat);
 
     bool firstFrame = true;
 

--- a/ogles_gpgpu/common/proc/yuv2rgb.cpp
+++ b/ogles_gpgpu/common/proc/yuv2rgb.cpp
@@ -7,8 +7,8 @@
 // Original shaders: https://github.com/BradLarson/GPUImage/blob/master/framework/Source/GPUImageVideoCamera.m
 // Modifications: Copyright (c) 2016-2017, David Hirvonen (this file)
 
-#include "../common_includes.h"
 #include "yuv2rgb.h"
+#include "../common_includes.h"
 
 using namespace std;
 using namespace ogles_gpgpu;
@@ -17,113 +17,118 @@ using namespace ogles_gpgpu;
 
 // BT.601, which is the standard for SDTV.
 GLfloat kColorConversion601Default[] = {
-    1.164,  1.164, 1.164,
+    1.164, 1.164, 1.164,
     0.0, -0.392, 2.017,
-    1.596, -0.813,   0.0,
+    1.596, -0.813, 0.0,
 };
 
 // BT.601 full range (ref: http://www.equasys.de/colorconversion.html)
 GLfloat kColorConversion601FullRangeDefault[] = {
-    1.0,    1.0,    1.0,
-    0.0,    -0.343, 1.765,
-    1.4,    -0.711, 0.0,
+    1.0, 1.0, 1.0,
+    0.0, -0.343, 1.765,
+    1.4, -0.711, 0.0,
 };
 
 // BT.709, which is the standard for HDTV.
 GLfloat kColorConversion709Default[] = {
-    1.164,  1.164, 1.164,
+    1.164, 1.164, 1.164,
     0.0, -0.213, 2.112,
-    1.793, -0.533,   0.0,
+    1.793, -0.533, 0.0,
 };
 
-GLfloat *kColorConversion601 = kColorConversion601Default;
-GLfloat *kColorConversion601FullRange = kColorConversion601FullRangeDefault;
-GLfloat *kColorConversion709 = kColorConversion709Default;
+GLfloat* kColorConversion601 = kColorConversion601Default;
+GLfloat* kColorConversion601FullRange = kColorConversion601FullRangeDefault;
+GLfloat* kColorConversion709 = kColorConversion709Default;
 
-void setColorConversion601( GLfloat conversionMatrix[9] ) {
+void setColorConversion601(GLfloat conversionMatrix[9]) {
     kColorConversion601 = conversionMatrix;
 }
 
-void setColorConversion601FullRange( GLfloat conversionMatrix[9] ) {
+void setColorConversion601FullRange(GLfloat conversionMatrix[9]) {
     kColorConversion601FullRange = conversionMatrix;
 }
 
-void setColorConversion709( GLfloat conversionMatrix[9] ) {
+void setColorConversion709(GLfloat conversionMatrix[9]) {
     kColorConversion709 = conversionMatrix;
 }
 
-// *INDENT-OFF*
-const char *kGPUImageYUVVideoRangeConversionForRGFragmentShaderString = OG_TO_STR(
-
+// clang-format off
+const char *kGPUImageYUVVideoRangeConversionForRGFragmentShaderString = 
 #if defined(OGLES_GPGPU_OPENGLES)
-  precision mediump float;
+OG_TO_STR(precision mediump float;)
 #endif
-
- varying OGLES_GPGPU_HIGHP vec2 vTexCoord;
+OG_TO_STR(
+          
+ varying vec2 vTexCoord;
 
  uniform sampler2D luminanceTexture;
  uniform sampler2D chrominanceTexture;
- uniform OGLES_GPGPU_MEDIUMP mat3 colorConversionMatrix;
+ uniform mat3 colorConversionMatrix;
 
  void main()
  {
-     OGLES_GPGPU_MEDIUMP vec3 yuv;
-     OGLES_GPGPU_LOWP vec3 rgb;
+     vec3 yuv;
+     vec3 rgb;
 
      yuv.x = texture2D(luminanceTexture, vTexCoord).r;
      yuv.yz = texture2D(chrominanceTexture, vTexCoord).rg - vec2(0.5, 0.5);
      rgb = colorConversionMatrix * yuv;
 
      gl_FragColor = vec4(rgb, 1);
- }
-);
-// *INDENT-ON*
+ });
+// clang-format on
 
-// *INDENT-OFF*
-const char *kGPUImageYUVFullRangeConversionForLAFragmentShaderString = OG_TO_STR(
+// clang-format off
+const char *kGPUImageYUVFullRangeConversionForLAFragmentShaderString =
+#if defined(OGLES_GPGPU_OPENGLES)
+OG_TO_STR(precision mediump float;)
+#endif
+OG_TO_STR(
 
- varying OGLES_GPGPU_HIGHP vec2 vTexCoord;
+ varying vec2 vTexCoord;
 
  uniform sampler2D luminanceTexture;
  uniform sampler2D chrominanceTexture;
- uniform OGLES_GPGPU_MEDIUMP mat3 colorConversionMatrix;
+ uniform mat3 colorConversionMatrix;
 
  void main()
  {
-     OGLES_GPGPU_MEDIUMP vec3 yuv;
-     OGLES_GPGPU_LOWP vec3 rgb;
+     vec3 yuv;
+     vec3 rgb;
 
      yuv.x = texture2D(luminanceTexture, vTexCoord).r;
      yuv.yz = texture2D(chrominanceTexture, vTexCoord).ra - vec2(0.5, 0.5);
      rgb = colorConversionMatrix * yuv;
 
      gl_FragColor = vec4(rgb, 1);
- }
-);
-// *INDENT-ON*
+ });
+// clang-format on
 
-// *INDENT-OFF*
-const char *kGPUImageYUVVideoRangeConversionForLAFragmentShaderString = OG_TO_STR(
-
- varying OGLES_GPGPU_HIGHP vec2 vTexCoord;
+// clang-format off
+const char *kGPUImageYUVVideoRangeConversionForLAFragmentShaderString =
+#if defined(OGLES_GPGPU_OPENGLES)
+OG_TO_STR(precision mediump float;)
+#endif
+OG_TO_STR(
+                                                                                  
+ varying vec2 vTexCoord;
 
  uniform sampler2D luminanceTexture;
  uniform sampler2D chrominanceTexture;
- uniform OGLES_GPGPU_MEDIUMP mat3 colorConversionMatrix;
+ uniform mat3 colorConversionMatrix;
 
  void main()
  {
-     OGLES_GPGPU_MEDIUMP vec3 yuv;
-     OGLES_GPGPU_LOWP vec3 rgb;
+     vec3 yuv;
+     vec3 rgb;
 
      yuv.x = texture2D(luminanceTexture, vTexCoord).r - (16.0/255.0);
      yuv.yz = texture2D(chrominanceTexture, vTexCoord).ra - vec2(0.5, 0.5);
      rgb = colorConversionMatrix * yuv;
 
      gl_FragColor = vec4(rgb, 1);
- }
-);
-// *INDENT-ON*
+ });
+// clang-format on
 
 // =================================================================================
 
@@ -138,7 +143,7 @@ void Yuv2RgbProc::setTextures(GLuint luminance, GLuint chrominance) {
     chrominanceTexture = chrominance;
 }
 
-void Yuv2RgbProc::filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target) {
+void Yuv2RgbProc::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target) {
     //FilterProcBase::filterShaderSetup(vShaderSrc, fShaderSrc, target);
 
     ProcBase::createShader(vShaderSrc, fShaderSrc, target);
@@ -211,4 +216,3 @@ int Yuv2RgbProc::render(int position) {
 
     return 0;
 }
-

--- a/ogles_gpgpu/common/proc/yuv2rgb.h
+++ b/ogles_gpgpu/common/proc/yuv2rgb.h
@@ -23,7 +23,6 @@ namespace ogles_gpgpu {
  */
 class Yuv2RgbProc : public FilterProcBase {
 public:
-
     /**
      * Constructor.
      */
@@ -32,7 +31,7 @@ public:
     /**
      * Return the processors name.
      */
-    virtual const char *getProcName() {
+    virtual const char* getProcName() {
         return "Yuv2RgbProc";
     }
 
@@ -45,21 +44,20 @@ public:
     /**
      * Render the output.
      */
-    virtual int render(int position=0);
+    virtual int render(int position = 0);
 
     /**
     * Create the shader program
     */
-    virtual void filterShaderSetup(const char *vShaderSrc, const char *fShaderSrc, GLenum target);
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
 
     void setTextures(GLuint luminanceTexture, GLuint chrominanceTexture);
 
 private:
-
     virtual void filterRenderPrepare();
 
-    static const char *vshaderYuv2RgbSrc;   // fragment shader source
-    static const char *fshaderYuv2RgbSrc;   // fragment shader source
+    static const char* vshaderYuv2RgbSrc; // fragment shader source
+    static const char* fshaderYuv2RgbSrc; // fragment shader source
 
     //GLProgram *yuvConversionProgram;
 
@@ -73,7 +71,7 @@ private:
     GLint yuvConversionChrominanceTextureUniform;
     GLint yuvConversionMatrixUniform;
 
-    const GLfloat *_preferredConversion;
+    const GLfloat* _preferredConversion;
 };
 }
 

--- a/ogles_gpgpu/common/tools.cpp
+++ b/ogles_gpgpu/common/tools.cpp
@@ -25,7 +25,7 @@ clock_t Tools::startTick = 0;
 vector<double> Tools::timeMeasurements;
 #endif
 
-void Tools::checkGLErr(const char *cls, const char *msg) {
+void Tools::checkGLErr(const char* cls, const char* msg) {
     GLenum err = glGetError();
     if (err != GL_NO_ERROR) {
         OG_LOGERR(cls, "%s - GL error '%d' occured", msg, err);
@@ -41,7 +41,7 @@ float Tools::getBiggerPOTValue(float v) {
     return powf(2.0f, ceilf(log2f(v)));
 }
 
-vector<string> Tools::split(const string &s, char delim) {
+vector<string> Tools::split(const string& s, char delim) {
     vector<string> elems;
     stringstream strs(s);
     string item;
@@ -59,7 +59,7 @@ void Tools::strReplaceAll(string& str, const string& from, const string& to) {
 
     size_t start_pos = 0;
 
-    while((start_pos = str.find(from, start_pos)) != string::npos) {
+    while ((start_pos = str.find(from, start_pos)) != string::npos) {
         str.replace(start_pos, from.length(), to);
         start_pos += to.length();
     }

--- a/ogles_gpgpu/common/tools.h
+++ b/ogles_gpgpu/common/tools.h
@@ -13,11 +13,11 @@
 #ifndef OGLES_GPGPU_COMMON_TOOLS
 #define OGLES_GPGPU_COMMON_TOOLS
 
-#include <vector>
-#include <string>
-#include <sstream>
-#include <ctime>
 #include <cstdio>
+#include <ctime>
+#include <sstream>
+#include <string>
+#include <vector>
 
 using namespace std;
 
@@ -32,7 +32,7 @@ public:
      * Check for an OpenGL error in the previous call(s). Produce error
      * message in class <cls> with prefix <msg>.
      */
-    static void checkGLErr(const char *cls, const char *msg);
+    static void checkGLErr(const char* cls, const char* msg);
 
     /**
      * Check if <v> is a power-of-two (POT) value.
@@ -47,7 +47,7 @@ public:
     /**
      * Split a string <s> by delimiter <delim>.
      */
-    static vector<string> split(const string &s, char delim = ' ');
+    static vector<string> split(const string& s, char delim = ' ');
 
     /**
      * Replace all strings <from> in <str> by <to>.
@@ -67,13 +67,11 @@ public:
 #endif
 
 private:
-
 #ifdef OGLES_GPGPU_BENCHMARK
     static clock_t startTick;
     static vector<double> timeMeasurements;
 #endif
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/common/types.cpp
+++ b/ogles_gpgpu/common/types.cpp
@@ -17,6 +17,8 @@ namespace ogles_gpgpu {
 
 Size2d::Size2d() {}
 
-Size2d::Size2d(int width, int height) : width(width), height(height) {}
-
+Size2d::Size2d(int width, int height)
+    : width(width)
+    , height(height) {
+}
 }

--- a/ogles_gpgpu/common/types.h
+++ b/ogles_gpgpu/common/types.h
@@ -29,10 +29,9 @@ typedef enum {
     RenderOrientationDiagonalMirrored
 } RenderOrientation;
 
-
 // Map camera orientation (in degrees) to RenderOrientation enum
 inline RenderOrientation degreesToOrientation(int degrees) {
-    switch(degrees) {
+    switch (degrees) {
     case 360:
     case 0:
         return ogles_gpgpu::RenderOrientationStd;
@@ -64,7 +63,12 @@ inline bool operator!=(const Size2d& lhs, const Size2d& rhs) {
 
 struct Rect2d {
     Rect2d() {}
-    Rect2d(int x, int y, int width, int height) : x(x), y(y), width(width), height(height) {}
+    Rect2d(int x, int y, int width, int height)
+        : x(x)
+        , y(y)
+        , width(width)
+        , height(height) {
+    }
     int x = 0, y = 0, width = 0, height = 0;
 };
 
@@ -81,7 +85,6 @@ struct Vec3f {
 struct Mat44f {
     GLfloat data[4][4];
 };
-
 }
 
 #endif

--- a/ogles_gpgpu/platform/android/egl.cpp
+++ b/ogles_gpgpu/platform/android/egl.cpp
@@ -21,11 +21,11 @@ EGLDisplay EGL::disp = EGL_NO_DISPLAY;
 bool EGL::setup(int rSize, int gSize, int bSize, int aSize, int depthSize) {
     // EGL config attributes
     const EGLint confAttr[] = {
-        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,	// use OpenGL ES 2.0, very important!
-        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,			// we will create a pixelbuffer surface
-        EGL_RED_SIZE, 	rSize,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT, // use OpenGL ES 2.0, very important!
+        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT, // we will create a pixelbuffer surface
+        EGL_RED_SIZE, rSize,
         EGL_GREEN_SIZE, gSize,
-        EGL_BLUE_SIZE, 	bSize,
+        EGL_BLUE_SIZE, bSize,
         EGL_ALPHA_SIZE, aSize,
         EGL_DEPTH_SIZE, depthSize,
         EGL_NONE
@@ -33,7 +33,7 @@ bool EGL::setup(int rSize, int gSize, int bSize, int aSize, int depthSize) {
 
     // EGL context attributes
     const EGLint ctxAttr[] = {
-        EGL_CONTEXT_CLIENT_VERSION, 2,				// use OpenGL ES 2.0, very important!
+        EGL_CONTEXT_CLIENT_VERSION, 2, // use OpenGL ES 2.0, very important!
         EGL_NONE
     };
 
@@ -53,7 +53,7 @@ bool EGL::setup(int rSize, int gSize, int bSize, int aSize, int depthSize) {
 
     OG_LOGINF("EGL", "EGL init with version %d.%d", eglMajVers, eglMinVers);
 
-    if (!eglChooseConfig(disp, confAttr, &conf, 1, &numConfigs)) {	// choose the first config
+    if (!eglChooseConfig(disp, confAttr, &conf, 1, &numConfigs)) { // choose the first config
         OG_LOGERR("EGL", "eglChooseConfig failed: %d", eglGetError());
         return false;
     }
@@ -81,7 +81,7 @@ bool EGL::createPBufferSurface(int w, int h) {
         EGL_NONE
     };
 
-    surface = eglCreatePbufferSurface(disp, conf, surfaceAttr);	// create a pixelbuffer surface
+    surface = eglCreatePbufferSurface(disp, conf, surfaceAttr); // create a pixelbuffer surface
     if (surface == EGL_NO_SURFACE) {
         OG_LOGERR("EGL", "eglCreatePbufferSurface failed: %d", eglGetError());
         return false;
@@ -122,7 +122,8 @@ void EGL::shutdown() {
 }
 
 void EGL::destroySurface() {
-    if (surface == EGL_NO_SURFACE) return;
+    if (surface == EGL_NO_SURFACE)
+        return;
 
     eglDestroySurface(disp, surface);
 

--- a/ogles_gpgpu/platform/android/egl.h
+++ b/ogles_gpgpu/platform/android/egl.h
@@ -59,7 +59,6 @@ private:
      */
     static void destroySurface();
 
-
     static EGLConfig conf;
     static EGLSurface surface;
     static EGLContext ctx;

--- a/ogles_gpgpu/platform/android/macros.h
+++ b/ogles_gpgpu/platform/android/macros.h
@@ -17,11 +17,17 @@
 
 #ifdef DEBUG
 
-#define OG_LOGINF(class, args...)  __android_log_write(ANDROID_LOG_INFO, "ogles_gpgpu", class); __android_log_write(ANDROID_LOG_INFO, "ogles_gpgpu", __FUNCTION__); __android_log_print(ANDROID_LOG_INFO, "ogles_gpgpu", args)
+#define OG_LOGINF(class, args...)                                       \
+    __android_log_write(ANDROID_LOG_INFO, "ogles_gpgpu", class);        \
+    __android_log_write(ANDROID_LOG_INFO, "ogles_gpgpu", __FUNCTION__); \
+    __android_log_print(ANDROID_LOG_INFO, "ogles_gpgpu", args)
 #else
 #define OG_LOGINF(class, args...)
 #endif
 
-#define OG_LOGERR(class, args...) __android_log_write(ANDROID_LOG_ERROR, "ogles_gpgpu", class); __android_log_write(ANDROID_LOG_ERROR, "ogles_gpgpu", __FUNCTION__); __android_log_print(ANDROID_LOG_ERROR, "ogles_gpgpu", args)
+#define OG_LOGERR(class, args...)                                        \
+    __android_log_write(ANDROID_LOG_ERROR, "ogles_gpgpu", class);        \
+    __android_log_write(ANDROID_LOG_ERROR, "ogles_gpgpu", __FUNCTION__); \
+    __android_log_print(ANDROID_LOG_ERROR, "ogles_gpgpu", args)
 
 #endif

--- a/ogles_gpgpu/platform/android/memtransfer_android.cpp
+++ b/ogles_gpgpu/platform/android/memtransfer_android.cpp
@@ -21,10 +21,10 @@ typedef struct android_native_base_t {
 } android_native_base_t;
 
 typedef struct native_handle {
-    int version;        /* sizeof(native_handle_t) */
-    int numFds;         /* number of file-descriptors at &data[0] */
-    int numInts;        /* number of ints at &data[numFds] */
-    int data[0];        /* numFds + numInts ints */
+    int version; /* sizeof(native_handle_t) */
+    int numFds; /* number of file-descriptors at &data[0] */
+    int numInts; /* number of ints at &data[numFds] */
+    int data[0]; /* numFds + numInts ints */
 } native_handle_t;
 
 typedef const native_handle_t* buffer_handle_t;
@@ -52,47 +52,52 @@ using namespace ogles_gpgpu;
 
 enum {
     /* buffer is never read in software */
-    GRALLOC_USAGE_SW_READ_NEVER   = 0x00000000,
+    GRALLOC_USAGE_SW_READ_NEVER = 0x00000000,
     /* buffer is rarely read in software */
-    GRALLOC_USAGE_SW_READ_RARELY  = 0x00000002,
+    GRALLOC_USAGE_SW_READ_RARELY = 0x00000002,
     /* buffer is often read in software */
-    GRALLOC_USAGE_SW_READ_OFTEN   = 0x00000003,
+    GRALLOC_USAGE_SW_READ_OFTEN = 0x00000003,
     /* mask for the software read values */
-    GRALLOC_USAGE_SW_READ_MASK    = 0x0000000F,
+    GRALLOC_USAGE_SW_READ_MASK = 0x0000000F,
 
     /* buffer is never written in software */
-    GRALLOC_USAGE_SW_WRITE_NEVER  = 0x00000000,
+    GRALLOC_USAGE_SW_WRITE_NEVER = 0x00000000,
     /* buffer is never written in software */
     GRALLOC_USAGE_SW_WRITE_RARELY = 0x00000020,
     /* buffer is never written in software */
-    GRALLOC_USAGE_SW_WRITE_OFTEN  = 0x00000030,
+    GRALLOC_USAGE_SW_WRITE_OFTEN = 0x00000030,
     /* mask for the software write values */
-    GRALLOC_USAGE_SW_WRITE_MASK   = 0x000000F0,
+    GRALLOC_USAGE_SW_WRITE_MASK = 0x000000F0,
 
     /* buffer will be used as an OpenGL ES texture */
-    GRALLOC_USAGE_HW_TEXTURE      = 0x00000100,
+    GRALLOC_USAGE_HW_TEXTURE = 0x00000100,
     /* buffer will be used as an OpenGL ES render target */
-    GRALLOC_USAGE_HW_RENDER       = 0x00000200,
+    GRALLOC_USAGE_HW_RENDER = 0x00000200,
     /* buffer will be used by the 2D hardware blitter */
-    GRALLOC_USAGE_HW_2D           = 0x00000400,
+    GRALLOC_USAGE_HW_2D = 0x00000400,
     /* buffer will be used with the framebuffer device */
-    GRALLOC_USAGE_HW_FB           = 0x00001000,
+    GRALLOC_USAGE_HW_FB = 0x00001000,
     /* mask for the software usage bit-mask */
-    GRALLOC_USAGE_HW_MASK         = 0x00001F00,
+    GRALLOC_USAGE_HW_MASK = 0x00001F00,
 };
 
 enum {
-    HAL_PIXEL_FORMAT_RGBA_8888          = 1,
-    HAL_PIXEL_FORMAT_RGBX_8888          = 2,
-    HAL_PIXEL_FORMAT_RGB_888            = 3,
-    HAL_PIXEL_FORMAT_RGB_565            = 4,
-    HAL_PIXEL_FORMAT_BGRA_8888          = 5,
-    HAL_PIXEL_FORMAT_RGBA_5551          = 6,
-    HAL_PIXEL_FORMAT_RGBA_4444          = 7,
+    HAL_PIXEL_FORMAT_RGBA_8888 = 1,
+    HAL_PIXEL_FORMAT_RGBX_8888 = 2,
+    HAL_PIXEL_FORMAT_RGB_888 = 3,
+    HAL_PIXEL_FORMAT_RGB_565 = 4,
+    HAL_PIXEL_FORMAT_BGRA_8888 = 5,
+    HAL_PIXEL_FORMAT_RGBA_5551 = 6,
+    HAL_PIXEL_FORMAT_RGBA_4444 = 7,
 };
 
-#define OG_DL_FUNC(hndl, fn, type) (type)dlsym(hndl, fn)
-#define OG_DL_FUNC_CHECK(hndl, fn_ptr, fn) if (!fn_ptr) { OG_LOGERR("MemTransferAndroid", "could not dynamically link func '%s': %s", fn, dlerror()); dlclose(hndl); return false; }
+#define OG_DL_FUNC(hndl, fn, type) (type) dlsym(hndl, fn)
+#define OG_DL_FUNC_CHECK(hndl, fn_ptr, fn)                                                          \
+    if (!fn_ptr) {                                                                                  \
+        OG_LOGERR("MemTransferAndroid", "could not dynamically link func '%s': %s", fn, dlerror()); \
+        dlclose(hndl);                                                                              \
+        return false;                                                                               \
+    }
 
 #pragma mark static initializations and methods
 
@@ -106,7 +111,7 @@ EGLExtFnCreateImage MemTransferAndroid::imageKHRCreate = NULL;
 EGLExtFnDestroyImage MemTransferAndroid::imageKHRDestroy = NULL;
 
 EGLExtFnCreateSyncKHR MemTransferAndroid::createKHRSync = NULL;
-EGLExtFnDestroySyncKHR  MemTransferAndroid::destroyKHRSync = NULL;
+EGLExtFnDestroySyncKHR MemTransferAndroid::destroyKHRSync = NULL;
 EGLExtFnClientWaitSyncKHR MemTransferAndroid::waitKHRSync = NULL;
 
 #if OPENGLES_GPGPU_HAS_NATIVE_FENCE_FD_ANDROID
@@ -115,7 +120,7 @@ EGLExtFnDupNativeFenceFDANDROID MemTransferAndroid::dupNativeFenceFDANDROID = NU
 
 bool MemTransferAndroid::initPlatformOptimizations() {
     // load necessary EGL extension functions
-    void *dlEGLhndl = dlopen("libEGL.so", RTLD_LAZY);
+    void* dlEGLhndl = dlopen("libEGL.so", RTLD_LAZY);
     if (!dlEGLhndl) {
         OG_LOGERR("MemTransferAndroid", "could not load EGL library: %s", dlerror());
         return false;
@@ -130,16 +135,16 @@ bool MemTransferAndroid::initPlatformOptimizations() {
 #if OPENGLES_GPGPU_HAS_NATIVE_FENCE_FD_ANDROID
     // Load sync points for ANDROID:
     dupNativeFenceFDANDROID = OG_DL_FUNC(dlEGLhndl, "eglDupNativeFenceFDANDROID", EGLExtFnDupNativeFenceFDANDROID);
-    //OG_DL_FUNC_CHECK(dlEGLhndl, dupNativeFenceFDANDROID, "eglDupNativeFenceFDANDROID");
+//OG_DL_FUNC_CHECK(dlEGLhndl, dupNativeFenceFDANDROID, "eglDupNativeFenceFDANDROID");
 #endif
 
     // Try loading egl{Create,Destroy,ClientWait}SyncKHR, else we will resort to glFinish():
     createKHRSync = OG_DL_FUNC(dlEGLhndl, "eglCreateSyncKHR", EGLExtFnCreateSyncKHR);
     //OG_DL_FUNC_CHECK(dlEGLhndl, createKHRSync, "eglCreateSyncKHR");
-    if(createKHRSync) {
+    if (createKHRSync) {
         destroyKHRSync = OG_DL_FUNC(dlEGLhndl, "eglDestroySyncKHR", EGLExtFnDestroySyncKHR);
         //OG_DL_FUNC_CHECK(dlEGLhndl, destroyKHRSync, "eglDestroySyncKHR");
-        if(destroyKHRSync) {
+        if (destroyKHRSync) {
             waitKHRSync = OG_DL_FUNC(dlEGLhndl, "eglClientWaitSyncKHR", EGLExtFnClientWaitSyncKHR);
             //OG_DL_FUNC_CHECK(dlEGLhndl, destroyKHRSync, "eglClientWaitSyncKHR");
         }
@@ -148,7 +153,7 @@ bool MemTransferAndroid::initPlatformOptimizations() {
     dlclose(dlEGLhndl);
 
     // load necessary Android GraphicBuffer functions
-    void *dlUIhndl = dlopen("libui.so", RTLD_LAZY);
+    void* dlUIhndl = dlopen("libui.so", RTLD_LAZY);
     if (!dlUIhndl) {
         OG_LOGERR("MemTransferAndroid", "could not load Android UI library: %s", dlerror());
         return false;
@@ -203,7 +208,7 @@ void MemTransferAndroid::releaseInput() {
         free(inputGraBufHndl);
 
         inputGraBufHndl = NULL;
-        inputNativeBuf = NULL;  // reset weak-ref pointer to NULL
+        inputNativeBuf = NULL; // reset weak-ref pointer to NULL
     }
 }
 
@@ -223,7 +228,7 @@ void MemTransferAndroid::releaseOutput() {
         free(outputGraBufHndl);
 
         outputGraBufHndl = NULL;
-        outputNativeBuf = NULL;  // reset weak-ref pointer to NULL
+        outputNativeBuf = NULL; // reset weak-ref pointer to NULL
     }
 }
 
@@ -236,14 +241,14 @@ void MemTransferAndroid::init() {
     mEGLDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 }
 
-GLuint MemTransferAndroid::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat, void *inputDataPtr) {
+GLuint MemTransferAndroid::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat, void* inputDataPtr) {
     assert(initialized && inTexW > 0 && inTexH > 0);
 
     if (inputDataPtr == NULL && inputW == inTexW && inputH == inTexH && inputPixelFormat == inputPxFormat) {
         return inputTexId; // no change
     }
 
-    if (preparedInput) {    // already prepared -- release buffers!
+    if (preparedInput) { // already prepared -- release buffers!
         releaseInput();
     }
 
@@ -269,10 +274,10 @@ GLuint MemTransferAndroid::prepareInput(int inTexW, int inTexH, GLenum inputPxFo
     // create graphic buffer
     inputGraBufHndl = malloc(OG_ANDROID_GRAPHIC_BUFFER_SIZE);
     graBufCreate(inputGraBufHndl, inputW, inputH, nativePxFmt,
-                 GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_SW_WRITE_OFTEN);  // is used as OpenGL texture and will be written often
+        GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_SW_WRITE_OFTEN); // is used as OpenGL texture and will be written often
 
     // get window buffer
-    inputNativeBuf = (struct ANativeWindowBuffer *)graBufGetNativeBuffer(inputGraBufHndl);
+    inputNativeBuf = (struct ANativeWindowBuffer*)graBufGetNativeBuffer(inputGraBufHndl);
 
     if (!inputNativeBuf) {
         OG_LOGERR("MemTransferAndroid", "error getting native window buffer for input");
@@ -282,10 +287,10 @@ GLuint MemTransferAndroid::prepareInput(int inTexW, int inTexH, GLenum inputPxFo
     // create image for reading back the results
     EGLint eglImgAttrs[] = { EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE, EGL_NONE };
     inputImage = imageKHRCreate(mEGLDisplay,
-                                EGL_NO_CONTEXT,
-                                EGL_NATIVE_BUFFER_ANDROID,
-                                (EGLClientBuffer)inputNativeBuf,
-                                eglImgAttrs);	// or NULL as last param?
+        EGL_NO_CONTEXT,
+        EGL_NATIVE_BUFFER_ANDROID,
+        (EGLClientBuffer)inputNativeBuf,
+        eglImgAttrs); // or NULL as last param?
 
     if (!inputImage) {
         OG_LOGERR("MemTransferAndroid", "error creating image KHR for input");
@@ -306,7 +311,7 @@ GLuint MemTransferAndroid::prepareOutput(int outTexW, int outTexH) {
         return outputTexId; // no change
     }
 
-    if (preparedOutput) {    // already prepared -- release buffers!
+    if (preparedOutput) { // already prepared -- release buffers!
         releaseOutput();
     }
 
@@ -329,20 +334,20 @@ GLuint MemTransferAndroid::prepareOutput(int outTexW, int outTexH) {
 
     // create empty texture space on GPU
     glTexImage2D(GL_TEXTURE_2D, 0,
-                 GL_RGBA,
-                 outputW, outputH, 0,
-                 inputPixelFormat, GL_UNSIGNED_BYTE,
-                 NULL);	// we do not need to pass texture data -> it will be generated!
+        GL_RGBA,
+        outputW, outputH, 0,
+        inputPixelFormat, GL_UNSIGNED_BYTE,
+        NULL); // we do not need to pass texture data -> it will be generated!
 
     Tools::checkGLErr("MemTransferAndroid", "fbo texture creation");
 
     // create graphic buffer
     outputGraBufHndl = malloc(OG_ANDROID_GRAPHIC_BUFFER_SIZE);
     graBufCreate(outputGraBufHndl, outputW, outputH, HAL_PIXEL_FORMAT_RGBA_8888,
-                 GRALLOC_USAGE_HW_RENDER | GRALLOC_USAGE_SW_READ_OFTEN);    // is render target and will be read often
+        GRALLOC_USAGE_HW_RENDER | GRALLOC_USAGE_SW_READ_OFTEN); // is render target and will be read often
 
     // get window buffer
-    outputNativeBuf = (struct ANativeWindowBuffer *)graBufGetNativeBuffer(outputGraBufHndl);
+    outputNativeBuf = (struct ANativeWindowBuffer*)graBufGetNativeBuffer(outputGraBufHndl);
 
     if (!outputNativeBuf) {
         OG_LOGERR("MemTransferAndroid", "error getting native window buffer for output");
@@ -352,10 +357,10 @@ GLuint MemTransferAndroid::prepareOutput(int outTexW, int outTexH) {
     // create image for reading back the results
     EGLint eglImgAttrs[] = { EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE, EGL_NONE };
     outputImage = imageKHRCreate(mEGLDisplay,
-                                 EGL_NO_CONTEXT,
-                                 EGL_NATIVE_BUFFER_ANDROID,
-                                 (EGLClientBuffer)outputNativeBuf,
-                                 eglImgAttrs);	// or NULL as last param?
+        EGL_NO_CONTEXT,
+        EGL_NATIVE_BUFFER_ANDROID,
+        (EGLClientBuffer)outputNativeBuf,
+        eglImgAttrs); // or NULL as last param?
 
     if (!outputImage) {
         OG_LOGERR("MemTransferAndroid", "error creating image KHR for output");
@@ -373,11 +378,11 @@ void MemTransferAndroid::flush(uint32_t us) {
     // https://github.com/android/platform_frameworks_base/blob/master/services/core/jni/com_android_server_AssetAtlasService.cpp#L169-L185
     EGLSyncKHR sync;
 
-    if(createKHRSync && destroyKHRSync) {
+    if (createKHRSync && destroyKHRSync) {
 
 #if OPENGLES_GPGPU_HAS_NATIVE_FENCE_FD_ANDROID
         // Give priority to eglDupNativeFenceFDANDROID
-        if(dupNativeFenceFDANDROID)  {
+        if (dupNativeFenceFDANDROID) {
             sync = eglCreateSyncKHR(mEGLDisplay, EGL_SYNC_NATIVE_FENCE_ANDROID, NULL);
             glFlush(); // getRenderEngine().flush();
 
@@ -394,20 +399,20 @@ void MemTransferAndroid::flush(uint32_t us) {
 #endif
 
         // Fallback mechanism:
-        if(waitKHRSync) {
+        if (waitKHRSync) {
             sync = createKHRSync(mEGLDisplay, EGL_SYNC_FENCE_KHR, NULL);
             if (sync != EGL_NO_SYNC_KHR) {
                 EGLint result = waitKHRSync(mEGLDisplay, sync, EGL_SYNC_FLUSH_COMMANDS_BIT_KHR, us);
                 EGLint eglErr = eglGetError();
                 if (result == EGL_TIMEOUT_EXPIRED_KHR) {
                     OG_LOGERR("MemTransferAndroid::flush:", "fence wait timed out");
-                } else if(eglErr != EGL_SUCCESS) {
+                } else if (eglErr != EGL_SUCCESS) {
                     OG_LOGERR("MemTransferAndroid::flush:", "error waiting on EGL fence: %#x", eglErr);
                 }
                 destroyKHRSync(mEGLDisplay, sync);
                 return;
             } else {
-                OG_LOGERR("MemTransferAndroid::flush:","captureScreen: error creating EGL fence: %#x", eglGetError());
+                OG_LOGERR("MemTransferAndroid::flush:", "captureScreen: error creating EGL fence: %#x", eglGetError());
             }
         }
     }
@@ -416,7 +421,7 @@ void MemTransferAndroid::flush(uint32_t us) {
     glFinish();
 }
 
-void MemTransferAndroid::toGPU(const unsigned char *buf) {
+void MemTransferAndroid::toGPU(const unsigned char* buf) {
     assert(preparedInput && inputImage && inputTexId > 0 && buf);
 
     // bind the input texture
@@ -428,17 +433,16 @@ void MemTransferAndroid::toGPU(const unsigned char *buf) {
     Tools::checkGLErr("MemTransferAndroid", "call to glEGLImageTargetTexture2DOES() for input");
 
     // lock the graphics buffer at graphicsPtr
-    unsigned char *graphicsPtr = (unsigned char *)lockBufferAndGetPtr(BUF_TYPE_INPUT);
+    unsigned char* graphicsPtr = (unsigned char*)lockBufferAndGetPtr(BUF_TYPE_INPUT);
 
     // copy whole image from "buf" to "graphicsPtr"
     memcpy(graphicsPtr, buf, inputW * inputH * 4);
 
     // unlock the graphics buffer again
     unlockBuffer(BUF_TYPE_INPUT);
-
 }
 
-void MemTransferAndroid::fromGPU(unsigned char *buf) {
+void MemTransferAndroid::fromGPU(unsigned char* buf) {
     assert(preparedOutput && outputImage && outputTexId > 0 && buf);
 
     // bind the output texture
@@ -450,7 +454,7 @@ void MemTransferAndroid::fromGPU(unsigned char *buf) {
     Tools::checkGLErr("MemTransferAndroid", "call to glEGLImageTargetTexture2DOES() for output");
 
     // lock the graphics buffer at graphicsPtr
-    const unsigned char *graphicsPtr = (const unsigned char *)lockBufferAndGetPtr(BUF_TYPE_OUTPUT);
+    const unsigned char* graphicsPtr = (const unsigned char*)lockBufferAndGetPtr(BUF_TYPE_OUTPUT);
 
     // copy whole image from "graphicsPtr" to "buf"
     memcpy(buf, graphicsPtr, outputW * outputH * 4);
@@ -460,7 +464,7 @@ void MemTransferAndroid::fromGPU(unsigned char *buf) {
 }
 
 // TODO: Move this to mem_transfer_optimized
-void MemTransferAndroid::fromGPU(FrameDelegate &delegate) {
+void MemTransferAndroid::fromGPU(FrameDelegate& delegate) {
     // bind the texture
     glBindTexture(GL_TEXTURE_2D, outputTexId);
 
@@ -469,8 +473,8 @@ void MemTransferAndroid::fromGPU(FrameDelegate &delegate) {
 
     Tools::checkGLErr("MemTransferAndroid", "call to glEGLImageTargetTexture2DOES() for output");
 
-    const void *pixelBufferAddr = lockBufferAndGetPtr(BUF_TYPE_OUTPUT);
-    delegate({outputW, outputH}, pixelBufferAddr, bytesPerRow());
+    const void* pixelBufferAddr = lockBufferAndGetPtr(BUF_TYPE_OUTPUT);
+    delegate({ outputW, outputH }, pixelBufferAddr, bytesPerRow());
 
     unlockBuffer(BUF_TYPE_OUTPUT);
 }
@@ -480,10 +484,10 @@ size_t MemTransferAndroid::bytesPerRow() {
     return (outputNativeBuf->stride * 4);
 }
 
-void *MemTransferAndroid::lockBufferAndGetPtr(BufType bufType) {
-    void *hndl;
+void* MemTransferAndroid::lockBufferAndGetPtr(BufType bufType) {
+    void* hndl;
     int usage;
-    unsigned char *memPtr;
+    unsigned char* memPtr;
 
     if (bufType == BUF_TYPE_INPUT) {
         hndl = inputGraBufHndl;
@@ -501,11 +505,11 @@ void *MemTransferAndroid::lockBufferAndGetPtr(BufType bufType) {
         OG_LOGERR("MemTransferAndroid", "GraphicBuffer lock returned invalid pointer");
     }
 
-    return (void *)memPtr;
+    return (void*)memPtr;
 }
 
 void MemTransferAndroid::unlockBuffer(BufType bufType) {
-    void *hndl = (bufType == BUF_TYPE_INPUT) ? inputGraBufHndl : outputGraBufHndl;
+    void* hndl = (bufType == BUF_TYPE_INPUT) ? inputGraBufHndl : outputGraBufHndl;
 
     graBufUnlock(hndl);
 }

--- a/ogles_gpgpu/platform/android/memtransfer_android.h
+++ b/ogles_gpgpu/platform/android/memtransfer_android.h
@@ -34,7 +34,6 @@
 // "Really I have no idea, but this should be big enough"
 #define OG_ANDROID_GRAPHIC_BUFFER_SIZE 1024
 
-
 // TODO: Disable for now, try cmake build test for availability:
 //
 // typedef EGLint eglDupNativeFenceFDANDROID(EGLDisplay dpy, EGLSyncKHR sync);
@@ -50,32 +49,32 @@ namespace ogles_gpgpu {
  */
 
 // constructor
-typedef void (*GraphicBufferFnCtor)(void *graphicBufHndl, uint32_t w, uint32_t h, uint32_t format, uint32_t usage);
+typedef void (*GraphicBufferFnCtor)(void* graphicBufHndl, uint32_t w, uint32_t h, uint32_t format, uint32_t usage);
 
 // deconstructor
-typedef void (*GraphicBufferFnDtor)(void *graphicBufHndl);
+typedef void (*GraphicBufferFnDtor)(void* graphicBufHndl);
 
 // getNativeBuffer
-typedef void* (*GraphicBufferFnGetNativeBuffer)(void *graphicBufHndl);
+typedef void* (*GraphicBufferFnGetNativeBuffer)(void* graphicBufHndl);
 
 // lock
-typedef int (*GraphicBufferFnLock)(void *graphicBufHndl, uint32_t usage, unsigned char **addr);
+typedef int (*GraphicBufferFnLock)(void* graphicBufHndl, uint32_t usage, unsigned char** addr);
 
 // unlock
-typedef int (*GraphicBufferFnUnlock)(void *graphicBufHndl);
+typedef int (*GraphicBufferFnUnlock)(void* graphicBufHndl);
 
 /**
  * typedefs to EGL extension functions for ImageKHR extension
  */
 
 // create ImageKHR
-typedef EGLImageKHR (*EGLExtFnCreateImage)(EGLDisplay dpy, EGLContext ctx, EGLenum target, EGLClientBuffer buffer, const EGLint *attribList);
+typedef EGLImageKHR (*EGLExtFnCreateImage)(EGLDisplay dpy, EGLContext ctx, EGLenum target, EGLClientBuffer buffer, const EGLint* attribList);
 
 // destroy ImageKHR
 typedef EGLBoolean (*EGLExtFnDestroyImage)(EGLDisplay dpy, EGLImageKHR image);
 
 //typedef EGLSyncKHR eglCreateSyncKHR(EGLDisplay py, EGLenum condition, const EGLint * attrib_list);
-typedef EGLSyncKHR (*EGLExtFnCreateSyncKHR)(EGLDisplay py, EGLenum condition, const EGLint * attrib_list);
+typedef EGLSyncKHR (*EGLExtFnCreateSyncKHR)(EGLDisplay py, EGLenum condition, const EGLint* attrib_list);
 
 //typedef EGLBoolean glDestroySyncKHR(EGLDisplay dpy, EGLSyncKHR sync);
 typedef EGLBoolean (*EGLExtFnDestroySyncKHR)(EGLDisplay dpy, EGLSyncKHR sync);
@@ -101,13 +100,14 @@ public:
     /**
      * Constructor. Set defaults.
      */
-    MemTransferAndroid() :  MemTransfer(),
-        inputGraBufHndl(NULL),
-        outputGraBufHndl(NULL),
-        inputNativeBuf(NULL),
-        outputNativeBuf(NULL),
-        inputImage(NULL),
-        outputImage(NULL) {
+    MemTransferAndroid()
+        : MemTransfer()
+        , inputGraBufHndl(NULL)
+        , outputGraBufHndl(NULL)
+        , inputNativeBuf(NULL)
+        , outputNativeBuf(NULL)
+        , inputImage(NULL)
+        , outputImage(NULL) {
     }
 
     /**
@@ -123,7 +123,7 @@ public:
     /**
      * Prepare for input frames of size <inTexW>x<inTexH>. Return a texture id for the input frames.
      */
-    virtual GLuint prepareInput(int inTexW, int inTexH, GLenum inputPxFormat = GL_RGBA, void *inputDataPtr = NULL);
+    virtual GLuint prepareInput(int inTexW, int inTexH, GLenum inputPxFormat = GL_RGBA, void* inputDataPtr = NULL);
 
     /**
      * Prepare for output frames of size <outTexW>x<outTexH>. Return a texture id for the output frames.
@@ -143,12 +143,12 @@ public:
     /**
      * Map data in <buf> to GPU.
      */
-    virtual void toGPU(const unsigned char *buf);
+    virtual void toGPU(const unsigned char* buf);
 
     /**
      * Map data from GPU to <buf>
      */
-    virtual void fromGPU(unsigned char *buf);
+    virtual void fromGPU(unsigned char* buf);
 
     /**
      * Inidcates whether or not this MemTransfer implementation
@@ -161,7 +161,7 @@ public:
     /**
      * Apply callback to FBO texture.
      */
-    virtual void fromGPU(FrameDelegate &delegate);
+    virtual void fromGPU(FrameDelegate& delegate);
 
     /**
      * Get bytes per row in underlying FBO.
@@ -173,7 +173,7 @@ public:
      * The input buffer will be locked for reading AND writing, while the
      * output buffer will be locked for reading only.
      */
-    virtual void *lockBufferAndGetPtr(BufType bufType);
+    virtual void* lockBufferAndGetPtr(BufType bufType);
 
     /**
      * Unlock the input or output buffer.
@@ -183,17 +183,17 @@ public:
     /**
      * EGL flush command: possibly faster alternative to glFinish() prior to GraphicBuffer use
      */
-    virtual void flush(uint32_t us = 2000000000 /* 2 sec */ );
+    virtual void flush(uint32_t us = 2000000000 /* 2 sec */);
 
 private:
-    static GraphicBufferFnCtor graBufCreate;        // function pointer to GraphicBufferFnCtor
-    static GraphicBufferFnDtor graBufDestroy;       // function pointer to GraphicBufferFnDtor
-    static GraphicBufferFnGetNativeBuffer graBufGetNativeBuffer;  // function pointer to GraphicBufferFnGetNativeBuffer
-    static GraphicBufferFnLock graBufLock;          // function pointer to GraphicBufferFnLock
-    static GraphicBufferFnUnlock graBufUnlock;      // function pointer to GraphicBufferFnUnlock
+    static GraphicBufferFnCtor graBufCreate; // function pointer to GraphicBufferFnCtor
+    static GraphicBufferFnDtor graBufDestroy; // function pointer to GraphicBufferFnDtor
+    static GraphicBufferFnGetNativeBuffer graBufGetNativeBuffer; // function pointer to GraphicBufferFnGetNativeBuffer
+    static GraphicBufferFnLock graBufLock; // function pointer to GraphicBufferFnLock
+    static GraphicBufferFnUnlock graBufUnlock; // function pointer to GraphicBufferFnUnlock
 
-    static EGLExtFnCreateImage  imageKHRCreate;     // function pointer to EGLExtFnCreateImage
-    static EGLExtFnDestroyImage  imageKHRDestroy;   // function pointer to EGLExtFnDestroyImage
+    static EGLExtFnCreateImage imageKHRCreate; // function pointer to EGLExtFnCreateImage
+    static EGLExtFnDestroyImage imageKHRDestroy; // function pointer to EGLExtFnDestroyImage
 
     static EGLExtFnCreateSyncKHR createKHRSync;
     static EGLExtFnDestroySyncKHR destroyKHRSync;
@@ -203,17 +203,16 @@ private:
     static EGLExtFnDupNativeFenceFDANDROID dupNativeFenceFDANDROID;
 #endif
 
-    void *inputGraBufHndl;      // Android GraphicBuffer handle for input
-    void *outputGraBufHndl;     // Android GraphicBuffer handle for output
+    void* inputGraBufHndl; // Android GraphicBuffer handle for input
+    void* outputGraBufHndl; // Android GraphicBuffer handle for output
 
-    ANativeWindowBuffer *inputNativeBuf;     // pointer to native window buffer for input (weak ref - do not free()!)
-    ANativeWindowBuffer *outputNativeBuf;	// pointer to native window buffer for output (weak ref - do not free()!)
+    ANativeWindowBuffer* inputNativeBuf; // pointer to native window buffer for input (weak ref - do not free()!)
+    ANativeWindowBuffer* outputNativeBuf; // pointer to native window buffer for output (weak ref - do not free()!)
 
-    EGLImageKHR inputImage;     // ImageKHR handle for input
-    EGLImageKHR outputImage;    // ImageKHR handle for output
+    EGLImageKHR inputImage; // ImageKHR handle for input
+    EGLImageKHR outputImage; // ImageKHR handle for output
 
-    EGLDisplay mEGLDisplay;  // active display
+    EGLDisplay mEGLDisplay; // active display
 };
-
 }
 #endif

--- a/ogles_gpgpu/platform/ios/memtransfer_ios.h
+++ b/ogles_gpgpu/platform/ios/memtransfer_ios.h
@@ -39,15 +39,17 @@ public:
     /**
      * Constructor. Set defaults.
      */
-    MemTransferIOS() :  MemTransfer(),
-        bufferAttr(NULL),
-        inputPixelBuffer(NULL),
-        outputPixelBuffer(NULL),
-        inputTexture(NULL),
-        outputTexture(NULL),
-        textureCache(NULL),
-        inputPixelBufferSize(0),
-        outputPixelBufferSize(0) { }
+    MemTransferIOS()
+        : MemTransfer()
+        , bufferAttr(NULL)
+        , inputPixelBuffer(NULL)
+        , outputPixelBuffer(NULL)
+        , inputTexture(NULL)
+        , outputTexture(NULL)
+        , textureCache(NULL)
+        , inputPixelBufferSize(0)
+        , outputPixelBufferSize(0) {
+    }
 
     /**
      * Deconstructor. Release in- and outputs.
@@ -62,7 +64,7 @@ public:
     /**
      * Prepare for input frames of size <inTexW>x<inTexH>. Return a texture id for the input frames.
      */
-    virtual GLuint prepareInput(int inTexW, int inTexH, GLenum inputPxFormat = GL_RGBA, void *inputDataPtr = NULL);
+    virtual GLuint prepareInput(int inTexW, int inTexH, GLenum inputPxFormat = GL_RGBA, void* inputDataPtr = NULL);
 
     /**
      * Prepare for output frames of size <outTexW>x<outTexH>. Return a texture id for the output frames.
@@ -82,12 +84,12 @@ public:
     /**
      * Map data in <buf> to GPU.
      */
-    virtual void toGPU(const unsigned char *buf);
+    virtual void toGPU(const unsigned char* buf);
 
     /**
      * Map data from GPU to <buf>
      */
-    virtual void fromGPU(unsigned char *buf);
+    virtual void fromGPU(unsigned char* buf);
 
     /**
      * Inidcates whether or not this MemTransfer implementation
@@ -100,7 +102,7 @@ public:
     /**
      * Apply callback to FBO texture.
      */
-    virtual void fromGPU(FrameDelegate &delegate);
+    virtual void fromGPU(FrameDelegate& delegate);
 
     /**
      * Get bytes per row in underlying FBO.
@@ -112,7 +114,7 @@ public:
      * The input buffer will be locked for reading AND writing, while the
      * output buffer will be locked for reading only.
      */
-    virtual void *lockBufferAndGetPtr(BufType bufType);
+    virtual void* lockBufferAndGetPtr(BufType bufType);
 
     /**
      * Unlock the input or output buffer.
@@ -123,27 +125,25 @@ private:
     /**
      * Sets <buf> and <lockOpt> to the necessary pointers/values according to <bufType>.
      */
-    void getPixelBufferAndLockFlags(BufType bufType, CVPixelBufferRef *buf, CVOptionFlags *lockOpt);
+    void getPixelBufferAndLockFlags(BufType bufType, CVPixelBufferRef* buf, CVOptionFlags* lockOpt);
 
+    CFMutableDictionaryRef bufferAttr; // buffer attributes
 
-    CFMutableDictionaryRef bufferAttr;  // buffer attributes
-
-    CVPixelBufferRef inputPixelBuffer;  // input pixel buffer
+    CVPixelBufferRef inputPixelBuffer; // input pixel buffer
     CVPixelBufferRef outputPixelBuffer; // output pixel buffer
 
     CVOpenGLESTextureRef lumaTexture = 0;
     CVOpenGLESTextureRef chromaTexture = 0;
 
-    CVOpenGLESTextureRef inputTexture = 0;  // input texture reference
+    CVOpenGLESTextureRef inputTexture = 0; // input texture reference
     CVOpenGLESTextureRef outputTexture = 0; // output texture reference
 
     CVOpenGLESTextureCacheRef textureCache; // common texture cache
 
-    size_t inputPixelBufferSize;    // input pixel buffer size in bytes
-    size_t outputPixelBufferSize;   // output pixel buffer size in bytes
+    size_t inputPixelBufferSize; // input pixel buffer size in bytes
+    size_t outputPixelBufferSize; // output pixel buffer size in bytes
 
     std::shared_ptr<Yuv2RgbProc> yuv2rgb;
 };
-
 }
 #endif

--- a/ogles_gpgpu/platform/opengl/gl_includes.h
+++ b/ogles_gpgpu/platform/opengl/gl_includes.h
@@ -11,6 +11,8 @@
  * OpenGL (not iOS or Android) : handle all
  */
 
+// clang-format off
+
 //define something for Windows (64-bit)
 #if defined(_WIN32) || defined(_WIN64)
 #  include <algorithm> // min/max
@@ -39,3 +41,5 @@
 #else
 #  error platform not supported.
 #endif
+
+// clang-format on

--- a/ogles_gpgpu/platform/osx/gl_includes.h
+++ b/ogles_gpgpu/platform/osx/gl_includes.h
@@ -12,5 +12,5 @@
  */
 
 #include <OpenGL/gl.h>
-#include <OpenGL/glu.h>
 #include <OpenGL/glext.h>
+#include <OpenGL/glu.h>

--- a/ogles_gpgpu/platform/osx/memtransfer_osx.cpp
+++ b/ogles_gpgpu/platform/osx/memtransfer_osx.cpp
@@ -81,29 +81,29 @@ void MemTransferOSX::init() {
 
     CFDictionaryRef empty;
     empty = CFDictionaryCreate(kCFAllocatorDefault, // our empty OSXurface properties dictionary
-                               NULL,
-                               NULL,
-                               0,
-                               &kCFTypeDictionaryKeyCallBacks,
-                               &kCFTypeDictionaryValueCallBacks);
+        NULL,
+        NULL,
+        0,
+        &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks);
     bufferAttr = CFDictionaryCreateMutable(kCFAllocatorDefault,
-                                           1,
-                                           &kCFTypeDictionaryKeyCallBacks,
-                                           &kCFTypeDictionaryValueCallBacks);
+        1,
+        &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks);
 
     CFDictionarySetValue(bufferAttr, kCVPixelBufferIOSurfacePropertiesKey, empty);
 
     // create texture cache
-    CGLContextObj glCtxPtr = (CGLContextObj) Core::getInstance()->getGLContextPtr();
+    CGLContextObj glCtxPtr = (CGLContextObj)Core::getInstance()->getGLContextPtr();
     OG_LOGINF("MemTransferOSX", "OpenGL ES context at %p", glCtxPtr);
 
     assert(glCtxPtr);
-    CVReturn res = CVOpenGLTextureCacheCreate((CFAllocatorRef) kCFAllocatorDefault,
-                   (CFDictionaryRef) NULL,
-                   (CGLContextObj) glCtxPtr,
-                   CGLGetPixelFormat(glCtxPtr),
-                   (CFDictionaryRef) NULL,
-                   &textureCache);
+    CVReturn res = CVOpenGLTextureCacheCreate((CFAllocatorRef)kCFAllocatorDefault,
+        (CFDictionaryRef)NULL,
+        (CGLContextObj)glCtxPtr,
+        CGLGetPixelFormat(glCtxPtr),
+        (CFDictionaryRef)NULL,
+        &textureCache);
 
     if (res != kCVReturnSuccess) {
         OG_LOGERR("MemTransferOSX", "CVOpenGLTextureCacheCreate error %d", res);
@@ -113,14 +113,14 @@ void MemTransferOSX::init() {
     MemTransfer::init();
 }
 
-GLuint MemTransferOSX::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat, void *inputDataPtr) {
+GLuint MemTransferOSX::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat, void* inputDataPtr) {
     assert(initialized && inTexW > 0 && inTexH > 0);
 
     if (inputDataPtr == NULL && inputW == inTexW && inputH == inTexH && inputPixelFormat == inputPxFormat) {
         return inputTexId; // no change
     }
 
-    if (preparedInput) {    // already prepared -- release buffers!
+    if (preparedInput) { // already prepared -- release buffers!
         releaseInput();
     }
 
@@ -147,11 +147,11 @@ GLuint MemTransferOSX::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat
     // create input pixel buffer if necessary
     if (!bufRef) {
         res = CVPixelBufferCreate(kCFAllocatorDefault,
-                                  inputW,
-                                  inputH,
-                                  pxBufFmt,
-                                  bufferAttr,
-                                  &bufRef);
+            inputW,
+            inputH,
+            pxBufFmt,
+            bufferAttr,
+            &bufRef);
 
         if (res != kCVReturnSuccess) {
             OG_LOGERR("MemTransferOSX", "CVPixelBufferCreate error %d (input)", res);
@@ -167,10 +167,10 @@ GLuint MemTransferOSX::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat
     // create input texture
     //error = CVOpenGLTextureCacheCreateTextureFromImage(kCFAllocatorDefault, textureCache, renderTarget, NULL, &renderTexture);
     res = CVOpenGLTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
-            textureCache,
-            bufRef,
-            NULL, // texture attributes
-            &texRef);
+        textureCache,
+        bufRef,
+        NULL, // texture attributes
+        &texRef);
 
     if (res != kCVReturnSuccess) {
         OG_LOGERR("MemTransferOSX", "CVOpenGLTextureCacheCreateTextureFromImage error %d (input)", res);
@@ -190,7 +190,7 @@ GLuint MemTransferOSX::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat
 
     // set member variables
     if (inputDataPtr == NULL) {
-        inputPixelBuffer = bufRef;  // only necessary if we did not specify our own pixel buffer via <inputDataPtr>
+        inputPixelBuffer = bufRef; // only necessary if we did not specify our own pixel buffer via <inputDataPtr>
     }
     inputTexture = texRef;
     preparedInput = true;
@@ -205,7 +205,7 @@ GLuint MemTransferOSX::prepareOutput(int outTexW, int outTexH) {
         return outputTexId; // no change
     }
 
-    if (preparedOutput) {    // already prepared -- release buffers!
+    if (preparedOutput) { // already prepared -- release buffers!
         releaseOutput();
     }
 
@@ -220,10 +220,10 @@ GLuint MemTransferOSX::prepareOutput(int outTexW, int outTexH) {
 
     // create output pixel buffer
     res = CVPixelBufferCreate(kCFAllocatorDefault,
-                              outputW, outputH,
-                              kCVPixelFormatType_32BGRA,    // !
-                              bufferAttr,
-                              &bufRef);
+        outputW, outputH,
+        kCVPixelFormatType_32BGRA, // !
+        bufferAttr,
+        &bufRef);
 
     if (res != kCVReturnSuccess) {
         OG_LOGERR("MemTransferOSX", "CVPixelBufferCreate error %d (output)", res);
@@ -235,10 +235,10 @@ GLuint MemTransferOSX::prepareOutput(int outTexW, int outTexH) {
 
     // create output texture
     res = CVOpenGLTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
-            textureCache,
-            bufRef,
-            NULL, // texture attributes
-            &texRef);
+        textureCache,
+        bufRef,
+        NULL, // texture attributes
+        &texRef);
 
     if (res != kCVReturnSuccess) {
         OG_LOGERR("MemTransferOSX", "CVOpenGLTextureCacheCreateTextureFromImage error %d (output)", res);
@@ -264,11 +264,11 @@ GLuint MemTransferOSX::prepareOutput(int outTexW, int outTexH) {
     return outputTexId;
 }
 
-void MemTransferOSX::toGPU(const unsigned char *buf) {
+void MemTransferOSX::toGPU(const unsigned char* buf) {
     assert(preparedInput && inputPixelBuffer && inputTexId > 0 && buf);
 
     // copy data to pixel buffer
-    void *pixelBufferAddr = lockBufferAndGetPtr(BUF_TYPE_INPUT);
+    void* pixelBufferAddr = lockBufferAndGetPtr(BUF_TYPE_INPUT);
     memcpy(pixelBufferAddr, buf, inputPixelBufferSize);
     unlockBuffer(BUF_TYPE_INPUT);
 
@@ -276,20 +276,20 @@ void MemTransferOSX::toGPU(const unsigned char *buf) {
     glBindTexture(GL_TEXTURE_2D, inputTexId);
 }
 
-void MemTransferOSX::fromGPU(unsigned char *buf) {
+void MemTransferOSX::fromGPU(unsigned char* buf) {
     assert(preparedOutput && outputPixelBuffer && outputTexId > 0 && buf);
 
     // bind the texture
     glBindTexture(GL_TEXTURE_2D, outputTexId);
 
-    const void *pixelBufferAddr = lockBufferAndGetPtr(BUF_TYPE_OUTPUT);
+    const void* pixelBufferAddr = lockBufferAndGetPtr(BUF_TYPE_OUTPUT);
     memcpy(buf, pixelBufferAddr, outputPixelBufferSize);
     unlockBuffer(BUF_TYPE_OUTPUT);
 }
 
 #pragma mark private methods
 
-void *MemTransferOSX::lockBufferAndGetPtr(BufType bufType) {
+void* MemTransferOSX::lockBufferAndGetPtr(BufType bufType) {
     // get the buffer reference and lock options
     CVPixelBufferRef buf;
     CVOptionFlags lockOpt;
@@ -321,10 +321,10 @@ void MemTransferOSX::unlockBuffer(BufType bufType) {
     }
 }
 
-void MemTransferOSX::getPixelBufferAndLockFlags(BufType bufType, CVPixelBufferRef *buf, CVOptionFlags *lockOpt) {
+void MemTransferOSX::getPixelBufferAndLockFlags(BufType bufType, CVPixelBufferRef* buf, CVOptionFlags* lockOpt) {
     if (bufType == BUF_TYPE_INPUT) {
         *buf = inputPixelBuffer;
-        *lockOpt = 0;                           // read and write
+        *lockOpt = 0; // read and write
     } else {
         *buf = outputPixelBuffer;
         *lockOpt = kCVPixelBufferLock_ReadOnly; // read only

--- a/ogles_gpgpu/platform/osx/memtransfer_osx.h
+++ b/ogles_gpgpu/platform/osx/memtransfer_osx.h
@@ -37,15 +37,17 @@ public:
     /**
      * Constructor. Set defaults.
      */
-    MemTransferOSX() :  MemTransfer(),
-        bufferAttr(NULL),
-        inputPixelBuffer(NULL),
-        outputPixelBuffer(NULL),
-        inputTexture(NULL),
-        outputTexture(NULL),
-        textureCache(NULL),
-        inputPixelBufferSize(0),
-        outputPixelBufferSize(0) { }
+    MemTransferOSX()
+        : MemTransfer()
+        , bufferAttr(NULL)
+        , inputPixelBuffer(NULL)
+        , outputPixelBuffer(NULL)
+        , inputTexture(NULL)
+        , outputTexture(NULL)
+        , textureCache(NULL)
+        , inputPixelBufferSize(0)
+        , outputPixelBufferSize(0) {
+    }
 
     /**
      * Deconstructor. Release in- and outputs.
@@ -60,7 +62,7 @@ public:
     /**
      * Prepare for input frames of size <inTexW>x<inTexH>. Return a texture id for the input frames.
      */
-    virtual GLuint prepareInput(int inTexW, int inTexH, GLenum inputPxFormat = GL_RGBA, void *inputDataPtr = NULL);
+    virtual GLuint prepareInput(int inTexW, int inTexH, GLenum inputPxFormat = GL_RGBA, void* inputDataPtr = NULL);
 
     /**
      * Prepare for output frames of size <outTexW>x<outTexH>. Return a texture id for the output frames.
@@ -80,19 +82,19 @@ public:
     /**
      * Map data in <buf> to GPU.
      */
-    virtual void toGPU(const unsigned char *buf);
+    virtual void toGPU(const unsigned char* buf);
 
     /**
      * Map data from GPU to <buf>
      */
-    virtual void fromGPU(unsigned char *buf);
+    virtual void fromGPU(unsigned char* buf);
 
     /**
      * Lock the input or output buffer and return its base address.
      * The input buffer will be locked for reading AND writing, while the
      * output buffer will be locked for reading only.
      */
-    virtual void *lockBufferAndGetPtr(BufType bufType);
+    virtual void* lockBufferAndGetPtr(BufType bufType);
 
     /**
      * Unlock the input or output buffer.
@@ -103,22 +105,20 @@ private:
     /**
      * Sets <buf> and <lockOpt> to the necessary pointers/values according to <bufType>.
      */
-    void getPixelBufferAndLockFlags(BufType bufType, CVPixelBufferRef *buf, CVOptionFlags *lockOpt);
+    void getPixelBufferAndLockFlags(BufType bufType, CVPixelBufferRef* buf, CVOptionFlags* lockOpt);
 
+    CFMutableDictionaryRef bufferAttr; // buffer attributes
 
-    CFMutableDictionaryRef bufferAttr;  // buffer attributes
-
-    CVPixelBufferRef inputPixelBuffer;  // input pixel buffer
+    CVPixelBufferRef inputPixelBuffer; // input pixel buffer
     CVPixelBufferRef outputPixelBuffer; // output pixel buffer
 
-    CVOpenGLTextureRef inputTexture;  // input texture reference
+    CVOpenGLTextureRef inputTexture; // input texture reference
     CVOpenGLTextureRef outputTexture; // output texture reference
 
     CVOpenGLTextureCacheRef textureCache; // common texture cache
 
-    size_t inputPixelBufferSize;    // input pixel buffer size in bytes
-    size_t outputPixelBufferSize;   // output pixel buffer size in bytes
+    size_t inputPixelBufferSize; // input pixel buffer size in bytes
+    size_t outputPixelBufferSize; // output pixel buffer size in bytes
 };
-
 }
 #endif

--- a/ogles_gpgpu/ut/CMakeLists.txt
+++ b/ogles_gpgpu/ut/CMakeLists.txt
@@ -2,7 +2,13 @@ set(test_name OGLES_GPGPU_Test)
 set(test_app test-ogles_gpgpu)
 
 add_executable(${test_app} test-ogles_gpgpu.cpp)
-target_link_libraries(${test_app} PUBLIC ogles_gpgpu ${OGLES_GPGPU_TEST_LIBS})
+
+if(TARGET ogles_gpgpu_cpu)
+  target_link_libraries(${test_app} PUBLIC ogles_gpgpu_cpu ${OGLES_GPGPU_TEST_LIBS})
+else()
+  target_link_libraries(${test_app} PUBLIC ogles_gpgpu ${OGLES_GPGPU_TEST_LIBS})
+endif()
+  
 set_property(TARGET ${test_app} PROPERTY FOLDER "app/tests")
 
 if(OGLES_GPGPU_DO_GPU_TESTING)

--- a/ogles_gpgpu/ut/CMakeLists.txt
+++ b/ogles_gpgpu/ut/CMakeLists.txt
@@ -5,7 +5,10 @@ add_executable(${test_app} test-ogles_gpgpu.cpp)
 target_link_libraries(${test_app} PUBLIC ogles_gpgpu ${OGLES_GPGPU_TEST_LIBS})
 set_property(TARGET ${test_app} PROPERTY FOLDER "app/tests")
 
-add_test(
-  NAME "${test_name}"
-  COMMAND "${test_app}"
-  )
+if(OGLES_GPGPU_DO_GPU_TESTING)
+  # TODO: Lightweight portable OpenGL context for mobile platforms  
+  gauze_add_test(
+    NAME "${test_name}"
+    COMMAND "${test_app}"
+    )
+endif()

--- a/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
+++ b/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
@@ -1,12 +1,24 @@
+#include <aglet/aglet.h>
+#include <aglet/GLContext.h>
+
 #include <gtest/gtest.h>
+
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/highgui.hpp>
 
-#include <GLFW/glfw3.h>
+// NOTE: GL_BGRA is absent in Android NDK
+// clang-format off
+#ifdef ANDROID
+#  define TEXTURE_FORMAT GL_RGBA
+#else
+#  define TEXTURE_FORMAT GL_BGRA
+#endif
+// clang-format off
 
 #include "../common/gl/memtransfer_optimized.h"
 
+// clang-format off
 #include "../common/proc/yuv2rgb.h"      // [0]
 #include "../common/proc/lnorm.h"        // [0]
 #include "../common/proc/video.h"        // [0]
@@ -39,6 +51,7 @@
 #include "../common/proc/rgb2hsv.h"      // [0]
 #include "../common/proc/hsv2rgb.h"      // [0]
 #include "../common/proc/remap.h"        // [ ] (needs work)
+// clang-format on
 
 // virtual (tested indirectly)
 //#include "../common/proc/filter3x3.h"
@@ -48,36 +61,14 @@
 // NA:
 //#include "../common/proc/disp.h"
 
-
-int main(int argc, char **argv) {
+int gauze_main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+    auto code = RUN_ALL_TESTS();
+    return code;
 }
 
-struct GLFWContext {
-    GLFWContext() {
-        // initialize glfw context
-        glfwInit();
-        glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-        context = glfwCreateWindow(640, 480, "", NULL, NULL);
-        glfwMakeContextCurrent(context);
-        glActiveTexture(GL_TEXTURE0);
-    }
-
-    operator bool() const {
-        return (context != nullptr);
-    }
-
-    ~GLFWContext() {
-        glfwDestroyWindow(context);
-        glfwTerminate();
-    }
-
-    GLFWwindow *context = nullptr;
-};
-
 struct GLTexture {
-    GLTexture(std::size_t width, std::size_t height, GLenum texType, void *data) {
+    GLTexture(std::size_t width, std::size_t height, GLenum texType, void* data) {
         glGenTextures(1, &texId);
         glBindTexture(GL_TEXTURE_2D, texId);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -100,9 +91,9 @@ struct GLTexture {
     GLuint texId;
 };
 
-static cv::Mat getImage(ogles_gpgpu::ProcInterface &proc, cv::Mat &frame) {
-    if(dynamic_cast<ogles_gpgpu::MemTransferOptimized*>(proc.getMemTransferObj())) {
-        ogles_gpgpu::MemTransfer::FrameDelegate delegate = [&](const ogles_gpgpu::Size2d &size, const void *pixels, size_t bytesPerRow) {
+static cv::Mat getImage(ogles_gpgpu::ProcInterface& proc, cv::Mat& frame) {
+    if (dynamic_cast<ogles_gpgpu::MemTransferOptimized*>(proc.getMemTransferObj())) {
+        ogles_gpgpu::MemTransfer::FrameDelegate delegate = [&](const ogles_gpgpu::Size2d& size, const void* pixels, size_t bytesPerRow) {
             frame = cv::Mat(size.height, size.width, CV_8UC4, (void*)pixels, bytesPerRow).clone();
         };
         proc.getResultData(delegate);
@@ -115,13 +106,13 @@ static cv::Mat getImage(ogles_gpgpu::ProcInterface &proc, cv::Mat &frame) {
 
 static cv::Mat getTestImage(int width, int height, int stripe, bool alpha) {
     // Create a test image:
-    cv::Mat test(480, 640, CV_8UC3, cv::Scalar::all(0));
-    cv::Point center(test.cols/2, test.rows/2);
-    for(int i = test.cols/2; i > 0; i -= stripe) {
-        cv::circle(test, center, i, cv::Scalar(rand()%255, rand()%255, rand()%255), -1, 8);
+    cv::Mat test(height, width, CV_8UC3, cv::Scalar::all(0));
+    cv::Point center(test.cols / 2, test.rows / 2);
+    for (int i = test.cols / 2; i > 0; i -= stripe) {
+        cv::circle(test, center, i, cv::Scalar(rand() % 255, rand() % 255, rand() % 255), -1, 8);
     }
 
-    if(alpha) {
+    if (alpha) {
         cv::cvtColor(test, test, cv::COLOR_BGR2BGRA); // add alpha
     }
     return test;
@@ -131,34 +122,72 @@ static cv::Mat getTestImage(int width, int height, int stripe, bool alpha) {
 //### Shader Testing ###
 //######################
 
+static int gWidth = 640;
+static int gHeight = 480;
+
+#if !defined(_WIN32) && !defined(_WIN64)
+// vs-14-2015 GLSL reports the following error due to internal preprocessor #define
+// > could not compile shader program.  error log:
+// > 0:1(380): preprocessor error: syntax error, unexpected HASH_TOKEN
+TEST(OGLESGPGPUTest, MedianProc) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    if(context && *context) {
+        cv::Mat test = getTestImage(gWidth, gHeight, 20, true);
+
+        glActiveTexture(GL_TEXTURE0);
+        ogles_gpgpu::VideoSource video;
+        ogles_gpgpu::MedianProc median;
+
+        video.set(&median);
+
+        cv::Mat noise = cv::Mat::zeros(test.rows, test.cols, CV_8UC1);
+        cv::randu(noise, 0, 255);
+        test.setTo(0, noise < 30);
+        test.setTo(255, noise > 225);
+
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
+
+        cv::Mat result;
+        getImage(median, result);
+        ASSERT_FALSE(result.empty());
+    }
+}
+#endif
+
+#if !defined(ANDROID)
+// glTexImage2D w/ GL_LUMINANCE or GL_LUMINANCE_ALPHA report error 1282 in tests w/ android-ndk-r10e-api-19
+// TODO: The GL_RED_EXT seems to be available in >= android-21
 TEST(OGLESGPGPUTest, Yuv2RgbProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();    
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
+    if (context && *context) {
         static const int width = 640, height = 480;
 
-        cv::Mat green(1, 1, CV_8UC3, cv::Scalar(0,255,0)), yuv;
+        cv::Mat green(1, 1, CV_8UC3, cv::Scalar(0, 255, 0)), yuv;
         cv::cvtColor(green, yuv, cv::COLOR_BGR2YUV);
-        cv::Vec3b &value = yuv.at<cv::Vec3b>(0,0);
+        cv::Vec3b& value = yuv.at<cv::Vec3b>(0, 0);
 
         // Create constant color buffers:
-        std::vector<std::uint8_t> y(width*height, value[0]), uv(width*height/2);
-        for(int i = 0; i < uv.size(); i += 2) {
-            uv[i+0] = value[1];
-            uv[i+1] = value[2];
+        std::vector<std::uint8_t> y(width * height, value[0]), uv(width * height / 2);
+        for (int i = 0; i < uv.size(); i += 2) {
+            uv[i + 0] = value[1];
+            uv[i + 1] = value[2];
         }
 
         // Luminance texture:
-        GLTexture luminanceTexture(width, height, GL_LUMINANCE, y.data());
+        GLTexture luminanceTexture(gWidth, gHeight, GL_LUMINANCE, y.data());
         ASSERT_EQ(glGetError(), GL_NO_ERROR);
 
         // Chrominance texture (interleaved):
-        GLTexture chrominanceTexture(width/2, height/2, GL_LUMINANCE_ALPHA, uv.data());
+        GLTexture chrominanceTexture(width / 2, height / 2, GL_LUMINANCE_ALPHA, uv.data());
         ASSERT_EQ(glGetError(), GL_NO_ERROR);
 
         ogles_gpgpu::Yuv2RgbProc yuv2rgb;
-        yuv2rgb.init(width, height, 0, true);
+        yuv2rgb.init(gWidth, gHeight, 0, true);
         yuv2rgb.setExternalInputDataFormat(0); // for yuv
-        yuv2rgb.getMemTransferObj()->setOutputPixelFormat(GL_BGRA);
+        yuv2rgb.getMemTransferObj()->setOutputPixelFormat(TEXTURE_FORMAT);
         yuv2rgb.createFBOTex(false);
         yuv2rgb.setTextures(luminanceTexture, chrominanceTexture);
         yuv2rgb.render();
@@ -167,23 +196,25 @@ TEST(OGLESGPGPUTest, Yuv2RgbProc) {
         getImage(yuv2rgb, result);
         ASSERT_FALSE(result.empty());
 
-        auto mu = cv::mean(result);
+        //auto mu = cv::mean(result);
         //ASSERT_EQ(mu[0], 0);
         //ASSERT_EQ(mu[1], 255);
         //ASSERT_EQ(mu[2], 0);
     }
 }
+#endif
 
 TEST(OGLESGPGPUTest, GrayScaleProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    if (context && *context) {
         cv::Mat test = getTestImage(640, 480, 10, true);
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::GrayscaleProc gray;
 
         video.set(&gray);
-        video({{test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA});
+        video({ { test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT });
 
         cv::Mat result;
         getImage(gray, result);
@@ -192,15 +223,17 @@ TEST(OGLESGPGPUTest, GrayScaleProc) {
 }
 
 TEST(OGLESGPGPUTest, AdaptThreshProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         cv::Mat test = getTestImage(640, 480, 10, true);
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::AdaptThreshProc thresh;
 
         video.set(&thresh);
-        video({{test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA});
+        video({ { test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT });
 
         cv::Mat result;
         getImage(thresh, result);
@@ -209,17 +242,19 @@ TEST(OGLESGPGPUTest, AdaptThreshProc) {
 }
 
 TEST(OGLESGPGPUTest, GainProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         static const int value = 1, g = 10;
-        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value,value,value,255));
+        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value, value, value, 255));
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::GainProc gain(g);
 
         video.set(&gain);
-        video({{test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA});
+        video({ { test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT });
 
         cv::Mat result;
         getImage(gain, result);
@@ -228,12 +263,14 @@ TEST(OGLESGPGPUTest, GainProc) {
 }
 
 TEST(OGLESGPGPUTest, BlendProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         const float alpha = 0.5f;
         const int value = 2;
         const int a = 1, b = 10;
-        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value,value,value,255));
+        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value, value, value, 255));
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -245,7 +282,7 @@ TEST(OGLESGPGPUTest, BlendProc) {
         gain10.add(&blend, 1);
 
         video.set(&gain1);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(blend, result);
@@ -254,19 +291,21 @@ TEST(OGLESGPGPUTest, BlendProc) {
 }
 
 TEST(OGLESGPGPUTest, FIFOProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::FIFOPRoc fifo(3);
         video.set(&fifo);
 
-        for(int i = 0; i<3; i++) {
-            cv::Mat test(640, 480, CV_8UC4, cv::Scalar(i,i,i,255));
-            video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        for (int i = 0; i < 3; i++) {
+            cv::Mat test(640, 480, CV_8UC4, cv::Scalar(i, i, i, 255));
+            video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
         }
 
-        for(int i = 0; i < 3; i++) {
+        for (int i = 0; i < 3; i++) {
             cv::Mat result;
             getImage(*fifo[i], result);
             ASSERT_EQ(cv::mean(result)[0], i);
@@ -275,8 +314,10 @@ TEST(OGLESGPGPUTest, FIFOProc) {
 }
 
 TEST(OGLESGPGPUTest, TransformProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::GainProc gain(1.f);
@@ -286,8 +327,8 @@ TEST(OGLESGPGPUTest, TransformProc) {
         gain.add(&transform);
 
         ogles_gpgpu::Mat44f matrix;
-        for(int y = 0; y < 4; y++) {
-            for(int x = 0; x < 4; x++) {
+        for (int y = 0; y < 4; y++) {
+            for (int x = 0; x < 4; x++) {
                 matrix.data[y][x] = 0;
             }
             matrix.data[y][y] = 1.f;
@@ -297,7 +338,7 @@ TEST(OGLESGPGPUTest, TransformProc) {
         transform.setTransformMatrix(matrix);
 
         cv::Mat test = getTestImage(640, 480, 10, true);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(transform, result);
@@ -306,24 +347,25 @@ TEST(OGLESGPGPUTest, TransformProc) {
 }
 
 TEST(OGLESGPGPUTest, DiffProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         const int value = 2;
         const int a = 1, b = 10;
-        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value,value,value,255));
+        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value, value, value, 255));
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::GainProc gain1(a), gain10(b);
         ogles_gpgpu::DiffProc diff;
 
-
         gain1.add(&diff, 1);
         gain1.add(&gain10);
         gain10.add(&diff, 0);
 
         video.set(&gain1);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(diff, result);
@@ -332,8 +374,10 @@ TEST(OGLESGPGPUTest, DiffProc) {
 }
 
 TEST(OGLESGPGPUTest, GaussianProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         cv::Mat test = getTestImage(640, 480, 1, true);
 
         glActiveTexture(GL_TEXTURE0);
@@ -342,7 +386,7 @@ TEST(OGLESGPGPUTest, GaussianProc) {
 
         video.set(&gauss1);
         gauss1.add(&gauss2);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(gauss2, result);
@@ -351,8 +395,10 @@ TEST(OGLESGPGPUTest, GaussianProc) {
 }
 
 TEST(OGLESGPGPUTest, GaussianOptProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         cv::Mat test = getTestImage(640, 480, 1, true);
 
         glActiveTexture(GL_TEXTURE0);
@@ -360,7 +406,7 @@ TEST(OGLESGPGPUTest, GaussianOptProc) {
         ogles_gpgpu::GaussOptProc gauss;
 
         video.set(&gauss);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(gauss, result);
@@ -369,8 +415,10 @@ TEST(OGLESGPGPUTest, GaussianOptProc) {
 }
 
 TEST(OGLESGPGPUTest, BoxOptProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         cv::Mat test = getTestImage(640, 480, 1, true);
 
         glActiveTexture(GL_TEXTURE0);
@@ -378,7 +426,7 @@ TEST(OGLESGPGPUTest, BoxOptProc) {
         ogles_gpgpu::BoxOptProc box;
 
         video.set(&box);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(box, result);
@@ -387,17 +435,19 @@ TEST(OGLESGPGPUTest, BoxOptProc) {
 }
 
 TEST(OGLESGPGPUTest, HessianProc) {
-    GLFWContext context;
-    if(context) {
-        cv::Mat test(480, 640, CV_8UC1, cv::Scalar::all(0));
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
+        cv::Mat test(gWidth, gHeight, CV_8UC1, cv::Scalar::all(0));
 
         static const int tic = 20;
-        for(int y = tic; y <= test.rows-tic; y+=tic) {
-            for(int x = tic; x <= test.cols-tic; x+=tic) {
-                cv::circle(test, {x,y}, 1, 255, -1, 8);
+        for (int y = tic; y <= test.rows - tic; y += tic) {
+            for (int x = tic; x <= test.cols - tic; x += tic) {
+                cv::circle(test, { x, y }, 1, 255, -1, 8);
             }
         }
-        cv::GaussianBlur(test, test, {7,7}, 1.0);
+        cv::GaussianBlur(test, test, { 7, 7 }, 1.0);
         cv::cvtColor(test, test, cv::COLOR_GRAY2BGR);
         cv::cvtColor(test, test, cv::COLOR_BGR2BGRA);
 
@@ -406,7 +456,7 @@ TEST(OGLESGPGPUTest, HessianProc) {
         ogles_gpgpu::HessianProc hessian(100.f);
 
         video.set(&hessian);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result, alpha;
         getImage(hessian, result);
@@ -416,16 +466,18 @@ TEST(OGLESGPGPUTest, HessianProc) {
 }
 
 TEST(OGLESGPGPUTest, LbpProc) {
-    GLFWContext context;
-    if(context) {
-        cv::Mat test = getTestImage(480, 640, 1, true);
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
+        cv::Mat test = getTestImage(gWidth, gHeight, 1, true);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::LbpProc lbp;
 
         video.set(&lbp);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(lbp, result);
@@ -433,42 +485,20 @@ TEST(OGLESGPGPUTest, LbpProc) {
     }
 }
 
-TEST(OGLESGPGPUTest, MedianProc) {
-    GLFWContext context;
-    if(context) {
-        cv::Mat test = getTestImage(480, 640, 20, true);
-
-        glActiveTexture(GL_TEXTURE0);
-        ogles_gpgpu::VideoSource video;
-        ogles_gpgpu::MedianProc median;
-
-        video.set(&median);
-
-        cv::Mat noise = cv::Mat::zeros(test.rows, test.cols, CV_8UC1);
-        cv::randu(noise,0,255);
-        test.setTo(0, noise < 30);
-        test.setTo(255, noise > 225);
-
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
-
-        cv::Mat result;
-        getImage(median, result);
-        ASSERT_FALSE(result.empty());
-    }
-}
-
 TEST(OGLESGPGPUTest, Fir3Proc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         const cv::Size size(640, 480);
-        const cv::Point center(size.width/2, size.height/2);
-        const float radius = size.height/2;
+        const cv::Point center(size.width / 2, size.height / 2);
+        const float radius = size.height / 2;
 
         std::vector<cv::Mat> test(3);
-        std::vector<int> values { 64, 128, 64 };
+        std::vector<int> values{ 64, 128, 64 };
 
-        for(int i = 0; i < 3; i++) {
-            auto &value = values[i];
+        for (int i = 0; i < 3; i++) {
+            auto& value = values[i];
             cv::Mat canvas(size, CV_8UC3, cv::Scalar(value, value, value, 255));
             cv::circle(canvas, center, radius, values[i], -1, 4);
             cv::cvtColor(canvas, canvas, cv::COLOR_BGR2BGRA);
@@ -482,7 +512,7 @@ TEST(OGLESGPGPUTest, Fir3Proc) {
         ogles_gpgpu::GainProc gain(1.f); // noop
         ogles_gpgpu::FifoProc fifo(3);
         ogles_gpgpu::Fir3Proc fir3(doRgb);
-        fir3.setWeights( {-0.25f, -0.25f, -0.25f}, {+0.50f, +0.50f, +0.50f}, {-0.25f, -0.25f, -0.25f} );
+        fir3.setWeights({ -0.25f, -0.25f, -0.25f }, { +0.50f, +0.50f, +0.50f }, { -0.25f, -0.25f, -0.25f });
 
         video.set(&gain);
         gain.add(&fifo);
@@ -490,8 +520,8 @@ TEST(OGLESGPGPUTest, Fir3Proc) {
         fifo.addWithDelay(&fir3, 1, 1);
         fifo.addWithDelay(&fir3, 2, 2);
 
-        for(int i = 0; i < 3; i++) {
-            video({test[i].cols, test[i].rows}, test[i].ptr<void>(), true, 0, GL_BGRA);
+        for (int i = 0; i < 3; i++) {
+            video({ test[i].cols, test[i].rows }, test[i].ptr<void>(), true, 0, TEXTURE_FORMAT);
         }
 
         cv::Mat result;
@@ -501,8 +531,10 @@ TEST(OGLESGPGPUTest, Fir3Proc) {
 }
 
 TEST(OGLESGPGPUTest, GradProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         cv::Mat test = getTestImage(640, 480, 2, true);
 
         glActiveTexture(GL_TEXTURE0);
@@ -510,7 +542,7 @@ TEST(OGLESGPGPUTest, GradProc) {
         ogles_gpgpu::GradProc grad;
 
         video.set(&grad);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(grad, result);
@@ -518,13 +550,14 @@ TEST(OGLESGPGPUTest, GradProc) {
     }
 }
 
-
 TEST(OGLESGPGPUTest, LowPassProc) {
-    GLFWContext context;
-    if(context) {
-        std::vector<cv::Mat> images {
-            cv::Mat(480, 640, CV_8UC4, cv::Scalar(0,0,0,255)),
-            cv::Mat(480, 640, CV_8UC4, cv::Scalar(255,255,255,255))
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
+        std::vector<cv::Mat> images{
+            cv::Mat(gWidth, gHeight, CV_8UC4, cv::Scalar(0, 0, 0, 255)),
+            cv::Mat(gWidth, gHeight, CV_8UC4, cv::Scalar(255, 255, 255, 255))
         };
 
         glActiveTexture(GL_TEXTURE0);
@@ -532,9 +565,9 @@ TEST(OGLESGPGPUTest, LowPassProc) {
         ogles_gpgpu::LowPassFilterProc low;
         video.set(&low);
 
-        for(int i = 0; i < 5; i++) {
-            cv::Mat &test = images[i%2];
-            video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        for (int i = 0; i < 5; i++) {
+            cv::Mat& test = images[i % 2];
+            video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
         }
 
         cv::Mat result;
@@ -544,11 +577,13 @@ TEST(OGLESGPGPUTest, LowPassProc) {
 }
 
 TEST(OGLESGPGPUTest, HighPassProc) {
-    GLFWContext context;
-    if(context) {
-        std::vector<cv::Mat> images {
-            cv::Mat(480, 640, CV_8UC4, cv::Scalar(0,0,0,255)),
-            cv::Mat(480, 640, CV_8UC4, cv::Scalar(255,255,255,255))
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
+        std::vector<cv::Mat> images{
+            cv::Mat(gWidth, gHeight, CV_8UC4, cv::Scalar(0, 0, 0, 255)),
+            cv::Mat(gWidth, gHeight, CV_8UC4, cv::Scalar(255, 255, 255, 255))
         };
 
         glActiveTexture(GL_TEXTURE0);
@@ -556,9 +591,9 @@ TEST(OGLESGPGPUTest, HighPassProc) {
         ogles_gpgpu::HighPassFilterProc high;
         video.set(&high);
 
-        for(int i = 0; i < 5; i++) {
-            cv::Mat &test = images[i%2];
-            video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        for (int i = 0; i < 5; i++) {
+            cv::Mat& test = images[i % 2];
+            video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
         }
 
         cv::Mat result;
@@ -568,8 +603,10 @@ TEST(OGLESGPGPUTest, HighPassProc) {
 }
 
 TEST(OGLESGPGPUTest, ThreshProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         cv::Mat test = getTestImage(640, 480, 2, true);
 
         glActiveTexture(GL_TEXTURE0);
@@ -577,7 +614,7 @@ TEST(OGLESGPGPUTest, ThreshProc) {
         ogles_gpgpu::ThreshProc thresh;
 
         video.set(&thresh);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(thresh, result);
@@ -586,8 +623,10 @@ TEST(OGLESGPGPUTest, ThreshProc) {
 }
 
 TEST(OGLESGPGPUTest, PyramidProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         cv::Mat test = getTestImage(640, 480, 2, true);
 
         glActiveTexture(GL_TEXTURE0);
@@ -595,7 +634,7 @@ TEST(OGLESGPGPUTest, PyramidProc) {
         ogles_gpgpu::PyramidProc pyramid(10);
         video.set(&pyramid);
 
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(pyramid, result);
@@ -604,9 +643,10 @@ TEST(OGLESGPGPUTest, PyramidProc) {
 }
 
 TEST(OGLESGPGPUTest, IxytProc) {
-    GLFWContext context;
-
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::GainProc gain(1.f);
@@ -619,9 +659,9 @@ TEST(OGLESGPGPUTest, IxytProc) {
         fifo.addWithDelay(&ixyt, 1, 1);
         fifo.addWithDelay(&ixyt, 0, 0);
 
-        for(int i = 0; i < 5; i++) {
+        for (int i = 0; i < 5; i++) {
             cv::Mat test = getTestImage(640, 480, 2, true);
-            video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+            video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
         }
 
         cv::Mat result;
@@ -635,8 +675,10 @@ TEST(OGLESGPGPUTest, IxytProc) {
 }
 
 TEST(OGLESGPGPUTest, TensorProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         cv::Mat test = getTestImage(640, 480, 2, true);
 
         glActiveTexture(GL_TEXTURE0);
@@ -644,7 +686,7 @@ TEST(OGLESGPGPUTest, TensorProc) {
         ogles_gpgpu::TensorProc tensor;
 
         video.set(&tensor);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(tensor, result);
@@ -653,13 +695,15 @@ TEST(OGLESGPGPUTest, TensorProc) {
 }
 
 TEST(OGLESGPGPUTest, ShiTomasiProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         cv::Mat test = getTestImage(640, 480, 2, true);
-        for(int i = 0; i < 100; i++) {
-            cv::Point p0(rand()%test.cols, rand()%test.rows);
-            cv::Point p1(rand()%test.cols, rand()%test.rows);
-            cv::line(test, p0, p1, {0,255,0}, 2, 8);
+        for (int i = 0; i < 100; i++) {
+            cv::Point p0(rand() % test.cols, rand() % test.rows);
+            cv::Point p1(rand() % test.cols, rand() % test.rows);
+            cv::line(test, p0, p1, { 0, 255, 0 }, 2, 8);
         }
 
         glActiveTexture(GL_TEXTURE0);
@@ -675,7 +719,7 @@ TEST(OGLESGPGPUTest, ShiTomasiProc) {
         gauss.add(&tensor);
         tensor.add(&shiTomasi);
 
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(shiTomasi, result);
@@ -684,13 +728,15 @@ TEST(OGLESGPGPUTest, ShiTomasiProc) {
 }
 
 TEST(OGLESGPGPUTest, HarrisProc) {
-    GLFWContext context;
-    if(context) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
         cv::Mat test = getTestImage(640, 480, 2, true);
-        for(int i = 0; i < 100; i++) {
-            cv::Point p0(rand()%test.cols, rand()%test.rows);
-            cv::Point p1(rand()%test.cols, rand()%test.rows);
-            cv::line(test, p0, p1, {0,255,0}, 2, 8);
+        for (int i = 0; i < 100; i++) {
+            cv::Point p0(rand() % test.cols, rand() % test.rows);
+            cv::Point p1(rand() % test.cols, rand() % test.rows);
+            cv::line(test, p0, p1, { 0, 255, 0 }, 2, 8);
         }
 
         glActiveTexture(GL_TEXTURE0);
@@ -706,7 +752,7 @@ TEST(OGLESGPGPUTest, HarrisProc) {
         gauss.add(&tensor);
         tensor.add(&harris);
 
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(harris, result);
@@ -715,17 +761,19 @@ TEST(OGLESGPGPUTest, HarrisProc) {
 }
 
 TEST(OGLESGPGPUTest, NmsProc) {
-    GLFWContext context;
-    if(context) {
-        cv::Mat test(480, 640, CV_8UC1, cv::Scalar::all(0));
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
+        cv::Mat test(gWidth, gHeight, CV_8UC1, cv::Scalar::all(0));
 
         static const int tic = 20;
-        for(int y = tic; y <= test.rows-tic; y+=tic) {
-            for(int x = tic; x <= test.cols-tic; x+=tic) {
-                cv::circle(test, {x,y}, 1, 255, -1, 8);
+        for (int y = tic; y <= test.rows - tic; y += tic) {
+            for (int x = tic; x <= test.cols - tic; x += tic) {
+                cv::circle(test, { x, y }, 1, 255, -1, 8);
             }
         }
-        cv::GaussianBlur(test, test, {7,7}, 1.0);
+        cv::GaussianBlur(test, test, { 7, 7 }, 1.0);
         cv::cvtColor(test, test, cv::COLOR_GRAY2BGR);
         cv::cvtColor(test, test, cv::COLOR_BGR2BGRA);
 
@@ -736,7 +784,7 @@ TEST(OGLESGPGPUTest, NmsProc) {
 
         video.set(&hessian);
         hessian.add(&nms);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result, alpha;
         getImage(nms, result);
@@ -746,9 +794,11 @@ TEST(OGLESGPGPUTest, NmsProc) {
 }
 
 TEST(OGLESGPGPUTest, FlowProc) {
-    GLFWContext context;
-    if(context) {
-        cv::Mat test = getTestImage(480, 640, 3, true);
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -758,11 +808,11 @@ TEST(OGLESGPGPUTest, FlowProc) {
         video.set(&gain);
         gain.add(&flow);
 
-        for(int i = 0; i < 5; i++) {
+        for (int i = 0; i < 5; i++) {
             cv::Mat shifted;
-            cv::Matx23f M(1,0,i*4,0,1,i*4);
+            cv::Matx23f M(1, 0, i * 4, 0, 1, i * 4);
             cv::warpAffine(test, shifted, M, test.size());
-            video({shifted.cols, shifted.rows}, shifted.ptr<void>(), true, 0, GL_BGRA);
+            video({ shifted.cols, shifted.rows }, shifted.ptr<void>(), true, 0, TEXTURE_FORMAT);
         }
 
         cv::Mat result;
@@ -772,16 +822,18 @@ TEST(OGLESGPGPUTest, FlowProc) {
 }
 
 TEST(OGLESGPGPUTest, Rgb2HsvProc) {
-    GLFWContext context;
-    if(context) {
-        cv::Mat test = getTestImage(480, 640, 3, true);
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::Rgb2HsvProc rgb2hsv;
 
         video.set(&rgb2hsv);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(rgb2hsv, result);
@@ -790,16 +842,18 @@ TEST(OGLESGPGPUTest, Rgb2HsvProc) {
 }
 
 TEST(OGLESGPGPUTest, Hsv2RgbProc) {
-    GLFWContext context;
-    if(context) {
-        cv::Mat test = getTestImage(480, 640, 3, true);
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::Hsv2RgbProc hsv2rgb;
 
         video.set(&hsv2rgb);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(hsv2rgb, result);
@@ -808,9 +862,11 @@ TEST(OGLESGPGPUTest, Hsv2RgbProc) {
 }
 
 TEST(OGLESGPGPUTest, LNormProc) {
-    GLFWContext context;
-    if(context) {
-        cv::Mat test = getTestImage(480, 640, 3, true);
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    if (context && *context) {
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -819,7 +875,7 @@ TEST(OGLESGPGPUTest, LNormProc) {
 
         video.set(&gainProc);
         gainProc.add(&normProc);
-        video({test.cols, test.rows}, test.ptr<void>(), true, 0, GL_BGRA);
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
         getImage(normProc, result);

--- a/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
+++ b/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
@@ -5,7 +5,6 @@
 
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
-#include <opencv2/highgui.hpp>
 
 // NOTE: GL_BGRA is absent in Android NDK
 // clang-format off


### PR DESCRIPTION
Transfer changes from working hunter.develop branch to hunter.  This includes: updates to clang-format formatting; shader unit tests via gtest+gauze+aglet; travis updates to support osmesa testing.  A condensed git history from the hunter.develop branch is included below.

* replace astyle w/ clang-format
  + disable default platform optimizations (leave this up to the user)
  + see .clang-format for coding style
  + Use style that closely matches original author’s style
  +  *INDENT-{OFF,ONF}* -> clang-format {off,on}
  +  add .clang-format
  + add platform specific gpu dependencies
  + shader string fixes to support visual studio
    - avoid #define inside shader strings for vs-14-2015
    - use consistent top level precision declarations (drop per delcaration precision)
    - add some missing astyle `// *INDENT-{ON,OFF}* ` guards
    - avoid median filter test for `defined(_WIN32) || defined(_WIN64)` due to reliance on internal #define
* update hunter: GIT_SUBMODULE feature, cellar feature, gauze package, etc
* use gauze and aglet for cross platform shader testing
  + gauze : for cross platform tests
  + aglet : for opengl context
  + update gtests to use gauze_main() + aglet::GLContext
  + add logic to support shader GTesting
     - host builds: desktop, iOS or Android
     - ci builds: android emulator (via gauze) or linux via osmesa (cpu)
* DisplayProc: add setter for glViewport offset
* remove default (i.e., hardcoded) gpu platform optimizations in core setup
  + user must explicitly call MemTransferFactory::tryEnablePlatformOptimizations()
  + we may want to support generic opengl calls with raw images/pixel buffers on an iOS platform, for example.
* enable windows tests; consider opengl context failure a test failure
* add missing dependencies to Config.cmake.in
* fix copyright/author for new files (header copy and paste issues)
* CMakeLists.txt: add platform specific gpu dependencies
* shader string fixes to support visual studio
  + avoid #define inside shader strings for vs-14-2015
  + use consistent top level precision declarations (drop per delcaration precision)
  + add some missing astyle `// *INDENT-{ON,OFF}* ` guards
  + avoid median filter test for `defined(_WIN32) || defined(_WIN64)` due to reliance on internal and incompatible #define
* use glfw for all but ios
* remove some unused; move gl* calls from headers to cpp files
* traivs.yml
  + update to trusty + gcc-pic-hid-sections
  + remove “—strip” for os=linux to avoid issue with autoconf project
  + fix linux==travis pip3
  + update linux easy_install3
* Appveyor.yml:
  + add explicit `image: Visual Studio 2015`
  + add MSYS_PATH for appveyor
  + simplify windows build matrix; exclude pr.* from branch builds
* restrict opencv build (used for unit tests) to core + imgproc + highgui (minimal)
* add glew.h before glfw.h for ogles_gpgpu test
* update/simplify travis; update copyright info
* hunterized unit tests (gtest)
   + add core GTest unit tests (use OpenCV for IO and datatypes)
   + add custom OpenCV CMAKE_ARGS to fix opencv os x build error
   + initial per filter coverage w/ simple setup + teardown + readout test (some value based tests added)
* update .gitignore
* fix new shader author/copyright notice
* move harris corner shader to designated shader
* add simple 3x3 hessian class; output(Ixx, Iyy, Ixy, det(H))
* add rgb2hsv and hsv2rgb shaders
* add simple gain shader
* provide two output options in hessian filter
   + det(H(R)) det(H(G)) det(H(B)) 1.0
   + Ixx(R) Ixy(R), Iyy(R), det(H(R))
* add newline to logging code
* load egl{Create,Destroy,ClientWait}SyncKHR sync operators dynamically, w/ fallback to glFinish()
* add missing libs to target_link_libraries; add missing defs to target_comile_definitions
* make nms output the peak value instead of binary value
* allow control of input and output channel for NMS processing
* add delegates for generic per filter "self reflection"
   + virtual void setPreProcessCallback(ProcDelegate &cb);
   + virtual void setPostProcessCallback(ProcDelegate &cb);
   + virtual void setPreRenderCallback(ProcDelegate &cb);
   + virtual void setPostRenderCallback(ProcDelegate &cb);
   + virtual void setPreInitCallback(ProcDelegate &cb);
   + virtual void setPostInitCallback(ProcDelegate &cb);
* add access method for shader program id
* comments, set inpuPixFormat on yuv->rgb shader initialization
* static analyzer: null assertions, order of initialization
* DiffProc (add missing destructor) : required by Xcode for shared_ptr<DiffProc> use in some cases
* FirProc: add alpha  (scale) and beta (offset) shader uniforms
* remove some custom/experimental shader source
* add missing strength/scale uniform in flow shader
* clear filters from procPasses in destructor
* optical flow destructor fix: Pr.fix.flow.destruction
* move forward declaration of ANativeWindowBuffer out of ogles_gpgpu na…
* add find_package calls for android system libs  based on oglplus cmake find_package boilerplate functions
* load egl{Create,Destroy,ClientWait}SyncKHR sync operators dynamically, w/ fallback to glFinish()
* add missing libs to target_link_libraries; add missing defs to target_comile_definitions
    > error: 'eglCreateSyncKHR' was not declared in this scope
* add MemTransferOpt::flush()
 - w/ MemTransferAndroid::flush() using:
 - eglClientWaitSyncKHR(mEGLDisplay, sync, EGL_SYNC_FLUSH_COMMANDS_BIT_KHR, us);
 - instead of `glFlush()` which is prefered w/ some drivers.
* make nms output the peak value instead of binary value
* allow control of input and output channel for NMS processing
* add access method for shader program id
* comments, set inpuPixFormat on yuv->rgb shader initialization