### PR TITLE
{DON'T MERGE} opengl es 3.0 suport (test)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rdparty/aglet"]
+	path = 3rdparty/aglet
+	url = https://github.com/elucideye/aglet.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,17 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 string(COMPARE EQUAL "${CMAKE_SYSTEM_NAME}" "Linux" is_linux)
 
+
 option(OGLES_GPGPU_BUILD_EXAMPLES "Build examples" OFF)
 option(OGLES_GPGPU_INSTALL "Perform installation" ON)
 option(OGLES_GPGPU_VERBOSE "Perform per filter logging" OFF)
 option(OGLES_GPGPU_BUILD_TESTS "Build shader unit tests" OFF)
 option(OGLES_GPGPU_USE_OSMESA "Use MESA CPU OpenGL (via glfw)" OFF)
+
+# !!! Make sure option OGLES_GPGPU_OPENG_ES3 occurs prior to the first
+# hunter_add_package() call.  This will allow us to modify settings
+# in dependencies appropriately (see cmake/Hunter/config.cmake)
+option(OGLES_GPGPU_OPENGL_ES3 "Use OpenGL ES 3.0" OFF)
 
 # See: cmake/Hunter/config.cmake
 hunter_add_package(Sugar)

--- a/bin/build-android.sh
+++ b/bin/build-android.sh
@@ -3,8 +3,9 @@
 TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
 CONFIG=Release
 
+echo "ARGC: ${#}"
 OGLES_GPGPU_OPENGL_ES3="OFF"
-if [[ "$#" -gt 1 ]] ; then
+if [[ "$#" -gt 0 ]] ; then
     OGLES_GPGPU_OPENGL_ES3="ON"
 fi
 

--- a/bin/build-android.sh
+++ b/bin/build-android.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
+CONFIG=Release
+
+OGLES_GPGPU_OPENGL_ES3="OFF"
+if [[ "$#" -gt 1 ]] ; then
+    OGLES_GPGPU_OPENGL_ES3="ON"
+fi
+
+ARGS=(
+    OGLES_GPGPU_BUILD_TESTS=ON
+    OGLES_GPGPU_OPENGL_ES3="${OGLES_GPGPU_OPENGL_ES3}"
+    HUNTER_CONFIGURATION_TYPES=${CONFIG}
+)
+
+polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --open --test --fwd ${ARGS[@]} --test

--- a/bin/build-ios.sh
+++ b/bin/build-ios.sh
@@ -4,8 +4,9 @@
 TOOLCHAIN=ios-10-1-arm64-dep-8-0-hid-sections
 CONFIG=Release
 
+echo "ARGC: ${#}"
 OGLES_GPGPU_OPENGL_ES3="OFF"
-if [[ "$#" -gt 1 ]] ; then
+if [[ "$#" -gt 0 ]] ; then
     OGLES_GPGPU_OPENGL_ES3="ON"
 fi
 

--- a/bin/build-ios.sh
+++ b/bin/build-ios.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+
+TOOLCHAIN=ios-10-1-arm64-dep-8-0-hid-sections
+CONFIG=Release
+
+OGLES_GPGPU_OPENGL_ES3="OFF"
+if [[ "$#" -gt 1 ]] ; then
+    OGLES_GPGPU_OPENGL_ES3="ON"
+fi
+
+ARGS=(
+    OGLES_GPGPU_BUILD_TESTS=ON
+    OGLES_GPGPU_OPENGL_ES3=${OGLES_GPGPU_OPENGL_ES3}
+    HUNTER_CONFIGURATION_TYPES=${CONFIG}
+)
+
+polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --open --fwd ${ARGS[@]} --test
+
+

--- a/bin/build-libcxx.sh
+++ b/bin/build-libcxx.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
-TOOLCHAIN=libcxx
+TOOLCHAIN=xcode
 CONFIG=Release
+
+OGLES_GPGPU_OPENGL_ES3="OFF"
+if [[ "$#" -gt 0 ]] ; then
+    OGLES_GPGPU_OPENGL_ES3="ON"
+fi
 
 ARGS=(
     OGLES_GPGPU_BUILD_TESTS=ON
-    OGLES_GPGPU_OPENGL_ES3=ON # not really, but enable pbo etc
+    OGLES_GPGPU_OPENGL_ES3=${OGLES_GPGPU_OPENGL_ES3}
     HUNTER_CONFIGURATION_TYPES=${CONFIG}
 )
-polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --test --fwd ${ARGS[@]} --test
-
+#polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --test --fwd ${ARGS[@]} --test
+polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --test --fwd ${ARGS[@]} --nobuild --open

--- a/bin/build-libcxx.sh
+++ b/bin/build-libcxx.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+TOOLCHAIN=libcxx
+CONFIG=Release
+
+ARGS=(
+    OGLES_GPGPU_BUILD_TESTS=ON
+    OGLES_GPGPU_OPENGL_ES3=ON # not really, but enable pbo etc
+    HUNTER_CONFIGURATION_TYPES=${CONFIG}
+)
+polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --test --fwd ${ARGS[@]} --test
+

--- a/bin/ogles_gpgpu-format.sh
+++ b/bin/ogles_gpgpu-format.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Note: When using clang-format the ${OGLES_GPGPU_ROOT}/.clang-format file
+# seems to be ignored if the root directory to this script is not
+# specified relative to the working directory:
+#
+# Suggested usage:
+#
+# cd ${OGLES_GPGPU_ROOT}
+# ./bin/ogles_gpgpu-format.sh lib
+# ./bin/ogles_gpgpu-format.sh test
+
+# Find all internal files, making sure to exlude 3rdparty subprojects
+function find_ogles_gpgpu_source()
+{
+    find $1 -name "*.h" -or -name "*.cpp" -or -name "*.hpp" -or -name "*.m" -or -name "*.mm"
+}
+
+input_dir=$1
+
+echo ${input_dir}
+
+find_ogles_gpgpu_source ${input_dir} | while read name
+do
+    echo $name
+    clang-format -i -style=file ${name}
+done
+
+

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -126,3 +126,17 @@ if(OGLES_GPGPU_USE_OSMESA)
   hunter_config(glfw VERSION ${HUNTER_glfw_VERSION} CMAKE_ARGS GLFW_USE_OSMESA=ON)
 endif()
 
+# Note: Aglet is currently used to provide an OpenGL context for the unit tests
+# We need to make sure it is configured appropriately to provide one of:
+# * OpenGL ES 3.0 (or OpenGL 3.0)
+# * OpenGL ES 2.0
+# The context must be allocated approprately and we need to pull in the correct
+# set of headers with mixing them.
+if(OGLES_GPGPU_OPENGL_ES3)
+  set(aglet_es3 ON)
+else()
+  set(aglet_es3 OFF)
+endif()
+
+hunter_config(aglet GIT_SUBMODULE "3rdparty/aglet" CMAKE_ARGS AGLET_OPENGL_ES3=${aglet_es3})
+

--- a/cmake/modules/FindOpenGLES3.cmake
+++ b/cmake/modules/FindOpenGLES3.cmake
@@ -1,0 +1,7 @@
+#  Copyright 2010-2014 Matus Chochlik. Distributed under the Boost
+#  Software License, Version 1.0. (See accompanying file
+#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+include(CommonFindMod)
+ogles_gpgpu_common_find_module(OpenGLES3 GLESv3 GLES3/gl3.h GLESv3)

--- a/ogles_gpgpu/CMakeLists.txt
+++ b/ogles_gpgpu/CMakeLists.txt
@@ -32,8 +32,17 @@ elseif(ANDROID)
   find_package(Android REQUIRED)
   find_package(Log REQUIRED)
   find_package(EGL REQUIRED)
-  find_package(OpenGLES2 REQUIRED)
-  target_link_libraries(ogles_gpgpu PUBLIC log android EGL GLESv2)
+
+  if(OGLES_GPGPU_OPENGL_ES3)
+    find_package(OpenGLES3 REQUIRED)
+    set(ogles_gpgpu_opengl_lib GLESv3)
+  else()
+    find_package(OpenGLES2 REQUIRED)
+    set(ogles_gpgpu_opengl_lib GLESv2)
+  endif()
+  target_link_libraries(ogles_gpgpu PUBLIC log android EGL ${ogles_gpgpu_opengl_lib})
+
+  
   target_compile_definitions(ogles_gpgpu PUBLIC EGL_EGLEXT_PROTOTYPES GL_GLEXT_PROTOTYPES)
 else()
 
@@ -79,7 +88,11 @@ else()
     set_property(TARGET ogles_gpgpu_cpu PROPERTY FOLDER "libs/ogles_gpgpu")
     target_include_directories(
       ogles_gpgpu_cpu PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>"
-      )    
+      )
+
+    if(OGLES_GPGPU_OPENGL_ES3)    
+      target_compile_definitions(ogles_gpgpu_cpu PUBLIC OGLES_GPGPU_OPENGL_ES3=1)
+    endif()
     
   endif()
 
@@ -100,7 +113,11 @@ endif()
 set_property(TARGET ogles_gpgpu PROPERTY FOLDER "libs/ogles_gpgpu")
 target_include_directories(
     ogles_gpgpu PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>"
-)
+    )
+
+if(OGLES_GPGPU_OPENGL_ES3)    
+  target_compile_definitions(ogles_gpgpu PUBLIC OGLES_GPGPU_OPENGL_ES3=1)
+endif()
 
 ## #################################################################
 ## Testing: 

--- a/ogles_gpgpu/common/common_includes.h
+++ b/ogles_gpgpu/common/common_includes.h
@@ -30,18 +30,15 @@
 #  define OGLES_GPGPU_WINDOWS 1
 #endif
 
-#ifdef OGLES_GPGPU_IOS
-#  define OGLES_GPGPU_OPENGLES 1
+#include "../platform/opengl/gl_includes.h"
+
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
 #  include "../platform/ios/gl_includes.h"
 #  include "macros.h"
-#elif OGLES_GPGPU_ANDROID
-#  define OGLES_GPGPU_OPENGLES 1
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
 #  include "../platform/android/gl_includes.h"
 #  include "../platform/android/macros.h"
 #  include "../platform/android/egl.h"
-#elif OGLES_GPGPU_OSX
-#  include "../platform/osx/gl_includes.h"
-#  include "macros.h"
 #else
 #  define OGLES_GPGPU_OPENGL 1
 #  include "../platform/opengl/gl_includes.h"
@@ -49,16 +46,9 @@
 #endif
 // clang-format on
 
-/* #ifdef __APPLE__ */
-/*     #include "../platform/ios/gl_includes.h" */
-/* 	#include "macros.h" */
-/* #elif __ANDROID__ */
-/*     #include "../platform/android/gl_includes.h" */
-/* 	#include "../platform/android/macros.h" */
-/* 	#include "../platform/android/egl.h" */
-/* #else */
-/* #error platform not supported. either __APPLE__ or __ANDROID__ must be defined. */
-/* #endif */
+#if defined(OGLES_GPGPU_ANDROID) || defined(OGLES_GPGPU_IOS)
+#  define OGLES_GPGPU_OPENGLES 1
+#endif
 
 #define BEGIN_OGLES_GPGPU namespace ogles_gpgpu {
 #define END_OGLES_GPGPU }

--- a/ogles_gpgpu/common/gl/fbo.h
+++ b/ogles_gpgpu/common/gl/fbo.h
@@ -32,7 +32,7 @@ public:
     /**
      * Constructor.
      */
-    FBO();
+    FBO(bool forOutput=true);
 
     /**
      * Deconstructor.
@@ -84,6 +84,11 @@ public:
      */
     void unbind();
 
+    /**
+     * Attach a pre-existing texture to the framebuffer.
+     */
+    virtual void attach(GLuint texId, GLenum attachment = GL_COLOR_ATTACHMENT0, GLenum target = GL_TEXTURE_2D);
+    
     /**
      * Will create a framebuffer output texture with texture id <attachedTexId>
      * and will bind it to this FBO.
@@ -140,7 +145,7 @@ protected:
 
     Core* core; // Core singleton
 
-    MemTransfer* memTransfer; // MemTransfer object associated with this FBO
+    MemTransfer* memTransfer = nullptr; // MemTransfer object associated with this FBO
 
     GLuint id; // OpenGL FBO id
     GLuint glTexUnit; // GL texture unit (to be used in glActiveTexture()) for output texture

--- a/ogles_gpgpu/common/gl/memtransfer.cpp
+++ b/ogles_gpgpu/common/gl/memtransfer.cpp
@@ -75,16 +75,18 @@ GLuint MemTransfer::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat, v
         return 0;
     }
 
-#if defined(OGLES_GPGPU_OPENGL_ES3)
     glBindTexture(GL_TEXTURE_2D, inputTexId);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+#if defined(OGLES_GPGPU_OPENGL_ES3)    
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, inputW, inputH, 0, inputPixelFormat, GL_UNSIGNED_BYTE, nullptr);
+#endif
     glBindTexture(GL_TEXTURE_2D, 0);
-    
+        
+#if defined(OGLES_GPGPU_OPENGL_ES3)
     // ::::::: allocate ::::::::::
     size_t pbo_size = inputW * inputH * 4;
     
@@ -102,8 +104,7 @@ GLuint MemTransfer::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat, v
     
     static const bool forOutput = false;
     fbo = new FBO(forOutput);
-#endif // OGLES_GPGPU_OPENGL_ES3
-
+#endif
     // done
     preparedInput = true;
 

--- a/ogles_gpgpu/common/gl/memtransfer.h
+++ b/ogles_gpgpu/common/gl/memtransfer.h
@@ -15,10 +15,14 @@
 #define OGLES_GPGPU_COMMON_GL_MEMTRANSFER
 
 #include "../common_includes.h"
+
 #include <functional>
+#include <memory>
 
 namespace ogles_gpgpu {
 
+class FBO;
+    
 /**
  * MemTransfer handles memory transfer and mapping between CPU and GPU memory space.
  * Input (from CPU to GPU space) and output (from GPU to CPU space) can be set up
@@ -176,7 +180,9 @@ protected:
     bool useRawPixels = false;
     
 #if defined(OGLES_GPGPU_OPENGL_ES3)
-    GLuint pbo;
+    FBO *fbo = nullptr;
+    GLuint pboRead;
+    GLuint pboWrite;
 #endif
 };
 }

--- a/ogles_gpgpu/common/gl/memtransfer.h
+++ b/ogles_gpgpu/common/gl/memtransfer.h
@@ -174,6 +174,10 @@ protected:
     GLenum outputPixelFormat;
 
     bool useRawPixels = false;
+    
+#if defined(OGLES_GPGPU_OPENGL_ES3)
+    GLuint pbo;
+#endif
 };
 }
 

--- a/ogles_gpgpu/common/gl/memtransfer_factory.cpp
+++ b/ogles_gpgpu/common/gl/memtransfer_factory.cpp
@@ -16,14 +16,12 @@
 //#include "../../platform/android/memtransfer_android.h"
 //#endif
 
-#ifdef OGLES_GPGPU_IOS
-#include "../../platform/ios/memtransfer_ios.h"
-#elif OGLES_GPGPU_OSX
-#include "../../platform/osx/memtransfer_osx.h"
-#elif OGLES_GPGPU_ANDROID
-#include "../../platform/android/memtransfer_android.h"
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
+#  include "../../platform/ios/memtransfer_ios.h"
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
+#  include "../../platform/android/memtransfer_android.h"
 #else
-#include "../../platform/opengl/memtransfer_generic.h"
+#  include "../../platform/opengl/memtransfer_generic.h"
 #endif
 
 using namespace ogles_gpgpu;
@@ -34,11 +32,9 @@ MemTransfer* MemTransferFactory::createInstance() {
     MemTransfer* instance = NULL;
 
     if (usePlatformOptimizations) { // create specialized instance
-#ifdef OGLES_GPGPU_IOS
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
         instance = (MemTransfer*)new MemTransferIOS();
-#elif OGLES_GPGPU_OSX
-        instance = (MemTransfer*)new MemTransferOSX();
-#elif OGLES_GPGPU_ANDROID
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
         instance = (MemTransfer*)new MemTransferAndroid();
 #else
         instance = (MemTransfer*)new MemTransfer();
@@ -53,11 +49,9 @@ MemTransfer* MemTransferFactory::createInstance() {
 }
 
 bool MemTransferFactory::tryEnablePlatformOptimizations() {
-#ifdef OGLES_GPGPU_IOS
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
     usePlatformOptimizations = MemTransferIOS::initPlatformOptimizations();
-#elif OGLES_GPGPU_OSX
-    usePlatformOptimizations = MemTransferOSX::initPlatformOptimizations();
-#elif OGLES_GPGPU_ANDROID
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
     usePlatformOptimizations = MemTransferAndroid::initPlatformOptimizations();
 #else
     usePlatformOptimizations = false;

--- a/ogles_gpgpu/common/gl/memtransfer_factory.cpp
+++ b/ogles_gpgpu/common/gl/memtransfer_factory.cpp
@@ -10,12 +10,7 @@
 #include "memtransfer_factory.h"
 #include "../core.h"
 
-//#ifdef __APPLE__
-//#include "../../platform/ios/memtransfer_ios.h"
-//#elif __ANDROID__
-//#include "../../platform/android/memtransfer_android.h"
-//#endif
-
+// clang-off
 #if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
 #  include "../../platform/ios/memtransfer_ios.h"
 #elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
@@ -23,6 +18,7 @@
 #else
 #  include "../../platform/opengl/memtransfer_generic.h"
 #endif
+// clang-on
 
 using namespace ogles_gpgpu;
 

--- a/ogles_gpgpu/common/proc/base/filterprocbase.cpp
+++ b/ogles_gpgpu/common/proc/base/filterprocbase.cpp
@@ -203,17 +203,21 @@ void FilterProcBase::filterRenderPrepare() {
 
     // set the viewport
     glViewport(0, 0, outFrameW, outFrameH);
-
-    glClear(GL_COLOR_BUFFER_BIT);
+    Tools::checkGLErr(getProcName(), "a");
+    
+    //glClear(GL_COLOR_BUFFER_BIT);
+    //Tools::checkGLErr(getProcName(), "b");
 
     assert(texTarget == GL_TEXTURE_2D); // texTarget = GL_TEXTURE_2D;
 
     // set input texture
     glActiveTexture(GL_TEXTURE0 + texUnit);
     glBindTexture(texTarget, texId); // bind input texture
-
+    Tools::checkGLErr(getProcName(), "c");
+    
     // set common uniforms
     glUniform1i(shParamUInputTex, texUnit);
+    Tools::checkGLErr(getProcName(), "d");
 }
 
 void FilterProcBase::filterRenderSetCoords() {

--- a/ogles_gpgpu/common/proc/base/procbase.h
+++ b/ogles_gpgpu/common/proc/base/procbase.h
@@ -240,7 +240,7 @@ protected:
 
     bool willDownscale; // is true if output size < input size.
 
-    GLenum inputDataFmt; // input pixel data format
+    GLenum inputDataFmt = 0; // input pixel data format
 
     int inFrameW = 0; // input frame width
     int inFrameH = 0; // input frame height

--- a/ogles_gpgpu/common/proc/three.cpp
+++ b/ogles_gpgpu/common/proc/three.cpp
@@ -115,8 +115,6 @@ void ThreeInputProc::filterRenderPrepare() {
     // set the viewport
     glViewport(0, 0, outFrameW, outFrameH);
 
-    glClear(GL_COLOR_BUFFER_BIT);
-
     // Bind input texture 1:
     glActiveTexture(GL_TEXTURE0 + texUnit);
     glBindTexture(texTarget, texId);

--- a/ogles_gpgpu/common/proc/two.cpp
+++ b/ogles_gpgpu/common/proc/two.cpp
@@ -104,8 +104,6 @@ void TwoInputProc::filterRenderPrepare() {
     // set the viewport
     glViewport(0, 0, outFrameW, outFrameH);
 
-    glClear(GL_COLOR_BUFFER_BIT);
-
     // Bind input texture 1:
     glActiveTexture(GL_TEXTURE0 + texUnit);
     glBindTexture(texTarget, texId);

--- a/ogles_gpgpu/common/proc/yuv2rgb.h
+++ b/ogles_gpgpu/common/proc/yuv2rgb.h
@@ -24,8 +24,12 @@ namespace ogles_gpgpu {
 class Yuv2RgbProc : public FilterProcBase {
 public:
 
-    enum YUVKind
-    {
+    enum ChannelKind {
+        kLA, // typically ES 2.0
+        kRG, // typically ES 3.0
+    };
+    
+    enum YUVKind {
         k601VideoRange,
         k601FullRange,
         k709Default
@@ -34,7 +38,7 @@ public:
     /**
      * Constructor.
      */
-    Yuv2RgbProc(YUVKind=k601VideoRange);
+    Yuv2RgbProc(YUVKind yuvKind=k601VideoRange, ChannelKind channelKind=kLA);
 
     /**
      * Return the processors name.
@@ -80,6 +84,7 @@ private:
     const GLfloat* _preferredConversion;
 
     YUVKind yuvKind = k601VideoRange;
+    ChannelKind channelKind = kLA;
 };
 }
 

--- a/ogles_gpgpu/common/proc/yuv2rgb.h
+++ b/ogles_gpgpu/common/proc/yuv2rgb.h
@@ -23,10 +23,18 @@ namespace ogles_gpgpu {
  */
 class Yuv2RgbProc : public FilterProcBase {
 public:
+
+    enum YUVKind
+    {
+        k601VideoRange,
+        k601FullRange,
+        k709Default
+    };
+    
     /**
      * Constructor.
      */
-    Yuv2RgbProc();
+    Yuv2RgbProc(YUVKind=k601VideoRange);
 
     /**
      * Return the processors name.
@@ -59,8 +67,6 @@ private:
     static const char* vshaderYuv2RgbSrc; // fragment shader source
     static const char* fshaderYuv2RgbSrc; // fragment shader source
 
-    //GLProgram *yuvConversionProgram;
-
     GLuint luminanceTexture;
     GLuint chrominanceTexture;
 
@@ -72,6 +78,8 @@ private:
     GLint yuvConversionMatrixUniform;
 
     const GLfloat* _preferredConversion;
+
+    YUVKind yuvKind = k601VideoRange;
 };
 }
 

--- a/ogles_gpgpu/platform/android/gl_includes.h
+++ b/ogles_gpgpu/platform/android/gl_includes.h
@@ -11,5 +11,5 @@
  * OpenGL ES 2.0 includes for Android.
  */
 
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
+//#include <GLES2/gl2.h>
+//#include <GLES2/gl2ext.h>

--- a/ogles_gpgpu/platform/ios/gl_includes.h
+++ b/ogles_gpgpu/platform/ios/gl_includes.h
@@ -11,5 +11,5 @@
  * OpenGL ES 2.0 includes for iOS.
  */
 
-#include <OpenGLES/ES2/gl.h>
-#include <OpenGLES/ES2/glext.h>
+//#include <OpenGLES/ES2/gl.h>
+//#include <OpenGLES/ES2/glext.h>

--- a/ogles_gpgpu/platform/opengl/gl_includes.h
+++ b/ogles_gpgpu/platform/opengl/gl_includes.h
@@ -11,6 +11,9 @@
  * OpenGL (not iOS or Android) : handle all
  */
 
+#ifndef OGLES_GPGPU_OPENGL_GL_INCLUDES
+#define OGLES_GPGPU_OPENGL_GL_INCLUDES
+
 // clang-format off
 
 //define something for Windows (64-bit)
@@ -19,27 +22,41 @@
 #  include <windows.h> // CMakeLists.txt defines NOMINMAX
 #  include <gl/glew.h>
 #  include <GL/gl.h>
-#  include <GL/glu.h>
 #elif __APPLE__
 #  include "TargetConditionals.h"
 #  if (TARGET_OS_IPHONE && TARGET_IPHONE_SIMULATOR) || TARGET_OS_IPHONE
-#    include <OpenGLES/ES2/gl.h>
-#    include <OpenGLES/ES2/glext.h>
+#    if defined(OGLES_GPGPU_OPENGL_ES3)
+#      include <OpenGLES/ES3/gl.h>
+#      include <OpenGLES/ES3/glext.h>
+#    else
+#      include <OpenGLES/ES2/gl.h>
+#      include <OpenGLES/ES2/glext.h>
+#    endif
 #  else
-#    include <OpenGL/gl.h>
-#    include <OpenGL/glu.h>
-#    include <OpenGL/glext.h>
+#    if defined(OGLES_GPGPU_OPENGL_ES3)
+#      include <OpenGL/gl3.h>
+#      include <OpenGL/gl3ext.h>
+#    else
+#      include <OpenGL/gl.h>
+#      include <OpenGL/glext.h>
+#    endif
 #  endif
 #elif defined(__ANDROID__) || defined(ANDROID)
-#  include <GLES2/gl2.h>
-#  include <GLES2/gl2ext.h>
+#  if defined(OGLES_GPGPU_OPENGL_ES3)
+#    include <GLES3/gl3.h>
+#    include <GLES3/gl3ext.h>
+#  else
+#    include <GLES2/gl2.h>
+#    include <GLES2/gl2ext.h>
+#  endif
 #elif defined(__linux__) || defined(__unix__) || defined(__posix__)
 #  define GL_GLEXT_PROTOTYPES 1
 #  include <GL/gl.h>
-#  include <GL/glu.h>
 #  include <GL/glext.h>
 #else
 #  error platform not supported.
 #endif
 
 // clang-format on
+
+#endif // OGLES_GPGPU_OPENGL_GL_INCLUDES

--- a/ogles_gpgpu/platform/sugar.cmake
+++ b/ogles_gpgpu/platform/sugar.cmake
@@ -11,15 +11,27 @@ endif()
 
 include(sugar_include)
 
-if(IOS)
-  sugar_include(ios)
-elseif(APPLE)
-  sugar_include(osx)
-elseif(ANDROID)
-  sugar_include(android)
+if(ANDROID OR IOS)
+  set(ogles_gpgpu_is_mobile TRUE)
 else()
-  message("include opengl platforms.............")
+  set(ogles_gpgpu_is_mobile FALSE)
+endif()
+
+# We will use the vanilla OpenGL implementation in case
+# of standard OpenGL platforms (i.e., not OpenGL ES) or
+# in cases where >= OpenGL ES 3.0 is available.  On those
+# platforms we can use PBO for efficient GPU->CPU reads.
+# If we are using OpenGL ES 2.0 on mobile devices then
+# we will use platform specific extensions to facilitate
+# efficient DMA reads of OpenGL textures.
+if(OGLES_GPGPU_OPENGL_ES3 OR NOT ${ogles_gpgpu_is_mobile})
   sugar_include(opengl)
+else()
+  if(IOS)
+    sugar_include(ios)
+  elseif(ANDROID)
+    sugar_include(android )
+  endif()
 endif()
 
 

--- a/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
+++ b/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
@@ -203,7 +203,7 @@ TEST(OGLESGPGPUTest, WriteAndRead) {
         auto almost_equal = [](const cv::Vec4b &a, const cv::Vec4b &b)
         {
             int delta = std::abs(static_cast<int>(a[0]) - static_cast<int>(b[0]));
-            if(delta > 1)
+            if(delta > 2)
             {
                 return false;
             }

--- a/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
+++ b/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
@@ -232,7 +232,7 @@ TEST(OGLESGPGPUTest, Yuv2RgbProc) {
         auto mu = cv::mean(result);
         ASSERT_LE(mu[0], 4);
         ASSERT_GE(mu[1], 250);
-        ASSERT_LE(mu[2], 4);
+        ASSERT_LE(mu[2], 8);
     }
 }
 


### PR DESCRIPTION
* make build scripts support opengl es 3.0 or 2.0
* add hunter notes
* set AGLET_OPENGL_ES3 == OGLES_GPGPU_OPENGL_ES3 (for unit tests)
* update yuv unit test and shaders (add control for coefficients)
* include master gl_includes.h for all platforms — contains internal preprocessor branching (all in one place)
* update aglet submodule
* remove glu includes
* remove glClear (texture is unbound) in filterRenderPrepare()
* add FindOpengLES3.cmake for android
* use latest AGLET via hunter GIT_SUBMODULE (TODO: use package)