### PR TITLE
opengl es 3.0 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "3rdparty/aglet"]
-	path = 3rdparty/aglet
-	url = https://github.com/elucideye/aglet.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rdparty/aglet"]
+	path = 3rdparty/aglet
+	url = https://github.com/elucideye/aglet.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,12 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-  URL "https://github.com/ruslo/hunter/archive/v0.19.29.tar.gz"
-  SHA1 "b0a69cd79597493f5e1e32d4cb77ff764807618a"  
-  LOCAL
-  )
+  URL "https://github.com/ruslo/hunter/archive/v0.19.36.tar.gz"
+  SHA1 "db6f5483795c56968fe628b3cc9791ec6627bdfc"
+  LOCAL  
+)
 
-project(ogles_gpgpu VERSION 0.2.0)
+project(ogles_gpgpu VERSION 0.2.1)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ option(OGLES_GPGPU_VERBOSE "Perform per filter logging" OFF)
 option(OGLES_GPGPU_BUILD_TESTS "Build shader unit tests" OFF)
 option(OGLES_GPGPU_USE_OSMESA "Use MESA CPU OpenGL (via glfw)" OFF)
 
+# !!! Make sure option OGLES_GPGPU_OPENG_ES3 occurs prior to the first
+# hunter_add_package() call.  This will allow us to modify settings
+# in dependencies appropriately (see cmake/Hunter/config.cmake)
+option(OGLES_GPGPU_OPENGL_ES3 "Use OpenGL ES 3.0" OFF)
+
 # See: cmake/Hunter/config.cmake
 hunter_add_package(Sugar)
 include("${SUGAR_ROOT}/cmake/Sugar")

--- a/bin/build-android.sh
+++ b/bin/build-android.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
+CONFIG=Release
+
+OGLES_GPGPU_OPENGL_ES3="OFF"
+if [[ "$#" -gt 0 ]] ; then
+    OGLES_GPGPU_OPENGL_ES3="ON"
+fi
+
+ARGS=(
+    OGLES_GPGPU_BUILD_TESTS=ON
+    OGLES_GPGPU_OPENGL_ES3="${OGLES_GPGPU_OPENGL_ES3}"
+    HUNTER_CONFIGURATION_TYPES=${CONFIG}
+)
+
+polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --open --test --fwd ${ARGS[@]} --test

--- a/bin/build-ios.sh
+++ b/bin/build-ios.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+
+TOOLCHAIN=ios-10-1-arm64-dep-8-0-hid-sections
+CONFIG=Release
+
+echo "ARGC: ${#}"
+OGLES_GPGPU_OPENGL_ES3="OFF"
+if [[ "$#" -gt 0 ]] ; then
+    OGLES_GPGPU_OPENGL_ES3="ON"
+fi
+
+ARGS=(
+    OGLES_GPGPU_BUILD_TESTS=ON
+    OGLES_GPGPU_OPENGL_ES3=${OGLES_GPGPU_OPENGL_ES3}
+    HUNTER_CONFIGURATION_TYPES=${CONFIG}
+)
+
+polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --open --fwd ${ARGS[@]} --test
+
+
+

--- a/bin/build-libcxx.sh
+++ b/bin/build-libcxx.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+TOOLCHAIN=xcode
+CONFIG=Release
+
+OGLES_GPGPU_OPENGL_ES3="OFF"
+if [[ "$#" -gt 0 ]] ; then
+    OGLES_GPGPU_OPENGL_ES3="ON"
+fi
+
+ARGS=(
+    OGLES_GPGPU_BUILD_TESTS=ON
+    OGLES_GPGPU_OPENGL_ES3=${OGLES_GPGPU_OPENGL_ES3}
+    HUNTER_CONFIGURATION_TYPES=${CONFIG}
+)
+
+polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --test --fwd ${ARGS[@]} --test
+

--- a/bin/ogles_gpgpu-format.sh
+++ b/bin/ogles_gpgpu-format.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Note: When using clang-format the ${OGLES_GPGPU_ROOT}/.clang-format file
+# seems to be ignored if the root directory to this script is not
+# specified relative to the working directory:
+#
+# Suggested usage:
+#
+# cd ${OGLES_GPGPU_ROOT}
+# ./bin/ogles_gpgpu-format.sh lib
+# ./bin/ogles_gpgpu-format.sh test
+
+# Find all internal files, making sure to exlude 3rdparty subprojects
+function find_ogles_gpgpu_source()
+{
+    find $1 -name "*.h" -or -name "*.cpp" -or -name "*.hpp" -or -name "*.m" -or -name "*.mm"
+}
+
+input_dir=$1
+
+echo ${input_dir}
+
+find_ogles_gpgpu_source ${input_dir} | while read name
+do
+    echo $name
+    clang-format -i -style=file ${name}
+done
+
+

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -126,3 +126,17 @@ if(OGLES_GPGPU_USE_OSMESA)
   hunter_config(glfw VERSION ${HUNTER_glfw_VERSION} CMAKE_ARGS GLFW_USE_OSMESA=ON)
 endif()
 
+# Note: Aglet is currently used to provide an OpenGL context for the unit tests
+# We need to make sure it is configured appropriately to provide one of:
+# * OpenGL ES 3.0 (or OpenGL 3.0)
+# * OpenGL ES 2.0
+# The context must be allocated approprately and we need to pull in the correct
+# set of headers with mixing them.
+if(OGLES_GPGPU_OPENGL_ES3)
+  set(aglet_es3 ON)
+else()
+  set(aglet_es3 OFF)
+endif()
+
+hunter_config(aglet GIT_SUBMODULE "3rdparty/aglet" CMAKE_ARGS AGLET_OPENGL_ES3=${aglet_es3})
+

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -138,5 +138,4 @@ else()
   set(aglet_es3 OFF)
 endif()
 
-hunter_config(aglet GIT_SUBMODULE "3rdparty/aglet" CMAKE_ARGS AGLET_OPENGL_ES3=${aglet_es3})
-
+hunter_config(aglet VERSION ${HUNTER_aglet_VERSION} CMAKE_ARGS AGLET_OPENGL_ES3=${aglet_es3})

--- a/cmake/modules/FindOpenGLES3.cmake
+++ b/cmake/modules/FindOpenGLES3.cmake
@@ -1,0 +1,7 @@
+#  Copyright 2010-2014 Matus Chochlik. Distributed under the Boost
+#  Software License, Version 1.0. (See accompanying file
+#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+include(CommonFindMod)
+ogles_gpgpu_common_find_module(OpenGLES3 GLESv3 GLES3/gl3.h GLESv3)

--- a/ogles_gpgpu/CMakeLists.txt
+++ b/ogles_gpgpu/CMakeLists.txt
@@ -32,8 +32,17 @@ elseif(ANDROID)
   find_package(Android REQUIRED)
   find_package(Log REQUIRED)
   find_package(EGL REQUIRED)
-  find_package(OpenGLES2 REQUIRED)
-  target_link_libraries(ogles_gpgpu PUBLIC log android EGL GLESv2)
+
+  if(OGLES_GPGPU_OPENGL_ES3)
+    find_package(OpenGLES3 REQUIRED)
+    set(ogles_gpgpu_opengl_lib GLESv3)
+  else()
+    find_package(OpenGLES2 REQUIRED)
+    set(ogles_gpgpu_opengl_lib GLESv2)
+  endif()
+  target_link_libraries(ogles_gpgpu PUBLIC log android EGL ${ogles_gpgpu_opengl_lib})
+
+  
   target_compile_definitions(ogles_gpgpu PUBLIC EGL_EGLEXT_PROTOTYPES GL_GLEXT_PROTOTYPES)
 else()
 
@@ -79,7 +88,11 @@ else()
     set_property(TARGET ogles_gpgpu_cpu PROPERTY FOLDER "libs/ogles_gpgpu")
     target_include_directories(
       ogles_gpgpu_cpu PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>"
-      )    
+      )
+
+    if(OGLES_GPGPU_OPENGL_ES3)    
+      target_compile_definitions(ogles_gpgpu_cpu PUBLIC OGLES_GPGPU_OPENGL_ES3=1)
+    endif()
     
   endif()
 
@@ -100,7 +113,11 @@ endif()
 set_property(TARGET ogles_gpgpu PROPERTY FOLDER "libs/ogles_gpgpu")
 target_include_directories(
     ogles_gpgpu PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>"
-)
+    )
+
+if(OGLES_GPGPU_OPENGL_ES3)    
+  target_compile_definitions(ogles_gpgpu PUBLIC OGLES_GPGPU_OPENGL_ES3=1)
+endif()
 
 ## #################################################################
 ## Testing: 

--- a/ogles_gpgpu/common/common_includes.h
+++ b/ogles_gpgpu/common/common_includes.h
@@ -30,18 +30,15 @@
 #  define OGLES_GPGPU_WINDOWS 1
 #endif
 
-#ifdef OGLES_GPGPU_IOS
-#  define OGLES_GPGPU_OPENGLES 1
+#include "../platform/opengl/gl_includes.h"
+
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
 #  include "../platform/ios/gl_includes.h"
 #  include "macros.h"
-#elif OGLES_GPGPU_ANDROID
-#  define OGLES_GPGPU_OPENGLES 1
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
 #  include "../platform/android/gl_includes.h"
 #  include "../platform/android/macros.h"
 #  include "../platform/android/egl.h"
-#elif OGLES_GPGPU_OSX
-#  include "../platform/osx/gl_includes.h"
-#  include "macros.h"
 #else
 #  define OGLES_GPGPU_OPENGL 1
 #  include "../platform/opengl/gl_includes.h"
@@ -49,16 +46,9 @@
 #endif
 // clang-format on
 
-/* #ifdef __APPLE__ */
-/*     #include "../platform/ios/gl_includes.h" */
-/* 	#include "macros.h" */
-/* #elif __ANDROID__ */
-/*     #include "../platform/android/gl_includes.h" */
-/* 	#include "../platform/android/macros.h" */
-/* 	#include "../platform/android/egl.h" */
-/* #else */
-/* #error platform not supported. either __APPLE__ or __ANDROID__ must be defined. */
-/* #endif */
+#if defined(OGLES_GPGPU_ANDROID) || defined(OGLES_GPGPU_IOS)
+#  define OGLES_GPGPU_OPENGLES 1
+#endif
 
 #define BEGIN_OGLES_GPGPU namespace ogles_gpgpu {
 #define END_OGLES_GPGPU }

--- a/ogles_gpgpu/common/gl/fbo.h
+++ b/ogles_gpgpu/common/gl/fbo.h
@@ -32,7 +32,7 @@ public:
     /**
      * Constructor.
      */
-    FBO();
+    FBO(bool forOutput=true);
 
     /**
      * Deconstructor.
@@ -84,6 +84,11 @@ public:
      */
     void unbind();
 
+    /**
+     * Attach a pre-existing texture to the framebuffer.
+     */
+    virtual void attach(GLuint texId, GLenum attachment = GL_COLOR_ATTACHMENT0, GLenum target = GL_TEXTURE_2D);
+    
     /**
      * Will create a framebuffer output texture with texture id <attachedTexId>
      * and will bind it to this FBO.
@@ -140,7 +145,7 @@ protected:
 
     Core* core; // Core singleton
 
-    MemTransfer* memTransfer; // MemTransfer object associated with this FBO
+    MemTransfer* memTransfer = nullptr; // MemTransfer object associated with this FBO
 
     GLuint id; // OpenGL FBO id
     GLuint glTexUnit; // GL texture unit (to be used in glActiveTexture()) for output texture

--- a/ogles_gpgpu/common/gl/memtransfer.cpp
+++ b/ogles_gpgpu/common/gl/memtransfer.cpp
@@ -8,6 +8,7 @@
 //
 
 #include "memtransfer.h"
+#include "fbo.h"
 
 using namespace ogles_gpgpu;
 
@@ -22,9 +23,9 @@ bool MemTransfer::initPlatformOptimizations() {
 #pragma mark constructor/deconstructor
 
 #if ANDROID
-#define DFLT_TEXTURE_FORMAT GL_RGBA
+#  define DFLT_TEXTURE_FORMAT GL_RGBA
 #else
-#define DFLT_TEXTURE_FORMAT GL_BGRA
+#  define DFLT_TEXTURE_FORMAT GL_BGRA
 #endif
 
 MemTransfer::MemTransfer() {
@@ -56,6 +57,10 @@ GLuint MemTransfer::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat, v
     if (preparedInput) { // already prepared -- release buffers!
         releaseInput();
     }
+    
+    if (inputPxFormat == 0) {
+        return 0;
+    }
 
     // set attributes
     inputW = inTexW;
@@ -70,11 +75,40 @@ GLuint MemTransfer::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat, v
         return 0;
     }
 
+    glBindTexture(GL_TEXTURE_2D, inputTexId);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+#if defined(OGLES_GPGPU_OPENGL_ES3)    
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, inputW, inputH, 0, inputPixelFormat, GL_UNSIGNED_BYTE, nullptr);
+#endif
+    glBindTexture(GL_TEXTURE_2D, 0);
+        
+#if defined(OGLES_GPGPU_OPENGL_ES3)
+    // ::::::: allocate ::::::::::
+    size_t pbo_size = inputW * inputH * 4;
+    
+    glGenBuffers(1, &pboWrite);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+    
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pboWrite);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+    
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, pbo_size, 0, GL_STREAM_DRAW);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+    
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+    
+    static const bool forOutput = false;
+    fbo = new FBO(forOutput);
+#endif
     // done
     preparedInput = true;
 
     // Texture data to be upladed with Core::setInputData(...)
-
     return inputTexId;
 }
 
@@ -117,6 +151,23 @@ GLuint MemTransfer::prepareOutput(int outTexW, int outTexH) {
 
     Tools::checkGLErr("MemTransfer", "fbo texture creation");
 
+#if defined(OGLES_GPGPU_OPENGL_ES3)
+    // ::::::: allocate ::::::::::
+    size_t pbo_size = outputW * outputH * 4;
+    
+    glGenBuffers(1, &pboRead);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+    
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pboRead);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+    
+    glBufferData(GL_PIXEL_PACK_BUFFER, pbo_size, 0, GL_DYNAMIC_READ);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+    
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+#endif // OGLES_GPGPU_OPENGL_ES3
+    
     // done
     preparedOutput = true;
 
@@ -128,6 +179,18 @@ void MemTransfer::releaseInput() {
         glDeleteTextures(1, &inputTexId);
         inputTexId = 0;
     }
+
+#if defined(OGLES_GPGPU_OPENGL_ES3)
+    if (pboWrite > 0) {
+        glDeleteBuffers(1, &pboWrite);
+        pboWrite = 0;
+    }
+    
+    if(fbo) {
+        delete fbo;
+        fbo = nullptr;
+    }
+#endif
 }
 
 void MemTransfer::releaseOutput() {
@@ -135,20 +198,69 @@ void MemTransfer::releaseOutput() {
         glDeleteTextures(1, &outputTexId);
         outputTexId = 0;
     }
+    
+#if defined(OGLES_GPGPU_OPENGL_ES3)
+    if (pboRead > 0) {
+        glDeleteBuffers(1, &pboRead);
+        pboRead = 0;
+    }
+#endif
+    
 }
 
 void MemTransfer::toGPU(const unsigned char* buf) {
     assert(preparedInput && inputTexId > 0 && buf);
 
+#if defined(OGLES_GPGPU_OPENGL_ES3)
+    std::size_t pbo_size = inputW * inputH * 4;
+
+    fbo->bind();
+    Tools::checkGLErr("MemTransfer", "toGPU (FBO::bind())");
+    
+    fbo->attach(inputTexId);
+    Tools::checkGLErr("MemTransfer", "toGPU (FBO::attach())");
+    
+    glBindTexture(GL_TEXTURE_2D, inputTexId); // bind input texture
+    Tools::checkGLErr("MemTransfer", "toGPU (glBindTexture)");
+    
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pboWrite);
+    Tools::checkGLErr("MemTransfer", "toGPU (glBindBuffer)");
+    
+#if defined(OGLES_GPGPU_OSX)
+    // TODO: glMapBufferRange does not seem to work in OS X
+    GLubyte* ptr = static_cast<GLubyte*>(glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY));
+    Tools::checkGLErr("MemTransfer", "toGPU (glMapBuffer)");                
+#else
+    GLubyte* ptr = static_cast<GLubyte*>(glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, pbo_size, GL_MAP_WRITE_BIT));
+    Tools::checkGLErr("MemTransfer", "toGPU (glMapBuffer)");                
+#endif
+    
+    if(ptr) {
+        memcpy(ptr, buf, pbo_size);
+        glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+        Tools::checkGLErr("MemTransfer", "toGPU (glMapBuffer)");
+    }
+    
+    // iOS requires GL_BGRA (DFLT_TEXTURE_FORMAT)
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, inputW, inputH, DFLT_TEXTURE_FORMAT, GL_UNSIGNED_BYTE, 0);
+    Tools::checkGLErr("MemTransfer", "toGPU (glTexSubImage2D)");
+    
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    Tools::checkGLErr("MemTransfer", "toGPU (glBindBuffer)");
+    
+    fbo->unbind();
+#else
+
     // set input texture
     glBindTexture(GL_TEXTURE_2D, inputTexId); // bind input texture
-
+    
     // copy data as texture to GPU (tested: OS X)
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, inputW, inputH, 0, inputPixelFormat, GL_UNSIGNED_BYTE, buf);
 
     // check for error
     Tools::checkGLErr("MemTransfer", "toGPU (glTexImage2D)");
+#endif
 
     setCommonTextureParams(0);
 }
@@ -156,13 +268,49 @@ void MemTransfer::toGPU(const unsigned char* buf) {
 void MemTransfer::fromGPU(unsigned char* buf) {
     assert(preparedOutput && outputTexId > 0 && buf);
 
+#if defined(OGLES_GPGPU_OPENGL_ES3)
+    size_t pbo_size = outputW * outputH * 4;    
+
+    // TODO: Reuse PBO, put side-by-side with FBO
+    // ::::::::: read ::::::::::::
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pboRead);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+    
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+
+    // Note glReadPixels last argument == 0 for PBO reads
+    glReadPixels(0, 0,outputW, outputH, DFLT_TEXTURE_FORMAT, GL_UNSIGNED_BYTE, 0); // GL_BGRA
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+    
+#if defined(OGLES_GPGPU_OSX)
+    // TODO: glMapBufferRange does not seem to work in OS X
+    GLubyte *ptr = static_cast<GLubyte *>(glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY));
+#else
+    GLubyte *ptr = static_cast<GLubyte *>(glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, pbo_size, GL_MAP_READ_BIT));
+#endif
+    Tools::checkGLErr("MemTransfer", "fromGPU");    
+    
+    memcpy(buf, ptr, pbo_size);
+
+    glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+    Tools::checkGLErr("MemTransfer", "fromGPU");    
+    
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+
+    glDeleteBuffers(1, &pboRead);
+    Tools::checkGLErr("MemTransfer", "fromGPU");
+#else
+    
     glBindTexture(GL_TEXTURE_2D, outputTexId);
+    Tools::checkGLErr("MemTransfer", "fromGPU: (glBindTexture)");
 
     // default (and slow) way using glReadPixels:
     glReadPixels(0, 0, outputW, outputH, outputPixelFormat, GL_UNSIGNED_BYTE, buf);
+    Tools::checkGLErr("MemTransfer", "fromGPU: (glReadPixels)");
+#endif
 
-    // check for error
-    Tools::checkGLErr("MemTransfer", "fromGPU (glReadPixels)");
 }
 
 // The zero copy fromGPU() call is not possibly with generic glReadPixels() access

--- a/ogles_gpgpu/common/gl/memtransfer.h
+++ b/ogles_gpgpu/common/gl/memtransfer.h
@@ -15,10 +15,14 @@
 #define OGLES_GPGPU_COMMON_GL_MEMTRANSFER
 
 #include "../common_includes.h"
+
 #include <functional>
+#include <memory>
 
 namespace ogles_gpgpu {
 
+class FBO;
+    
 /**
  * MemTransfer handles memory transfer and mapping between CPU and GPU memory space.
  * Input (from CPU to GPU space) and output (from GPU to CPU space) can be set up
@@ -174,6 +178,12 @@ protected:
     GLenum outputPixelFormat;
 
     bool useRawPixels = false;
+    
+#if defined(OGLES_GPGPU_OPENGL_ES3)
+    FBO *fbo = nullptr;
+    GLuint pboRead;
+    GLuint pboWrite;
+#endif
 };
 }
 

--- a/ogles_gpgpu/common/gl/memtransfer_factory.cpp
+++ b/ogles_gpgpu/common/gl/memtransfer_factory.cpp
@@ -10,21 +10,15 @@
 #include "memtransfer_factory.h"
 #include "../core.h"
 
-//#ifdef __APPLE__
-//#include "../../platform/ios/memtransfer_ios.h"
-//#elif __ANDROID__
-//#include "../../platform/android/memtransfer_android.h"
-//#endif
-
-#ifdef OGLES_GPGPU_IOS
-#include "../../platform/ios/memtransfer_ios.h"
-#elif OGLES_GPGPU_OSX
-#include "../../platform/osx/memtransfer_osx.h"
-#elif OGLES_GPGPU_ANDROID
-#include "../../platform/android/memtransfer_android.h"
+// clang-off
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
+#  include "../../platform/ios/memtransfer_ios.h"
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
+#  include "../../platform/android/memtransfer_android.h"
 #else
-#include "../../platform/opengl/memtransfer_generic.h"
+#  include "../../platform/opengl/memtransfer_generic.h"
 #endif
+// clang-on
 
 using namespace ogles_gpgpu;
 
@@ -34,11 +28,9 @@ MemTransfer* MemTransferFactory::createInstance() {
     MemTransfer* instance = NULL;
 
     if (usePlatformOptimizations) { // create specialized instance
-#ifdef OGLES_GPGPU_IOS
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
         instance = (MemTransfer*)new MemTransferIOS();
-#elif OGLES_GPGPU_OSX
-        instance = (MemTransfer*)new MemTransferOSX();
-#elif OGLES_GPGPU_ANDROID
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
         instance = (MemTransfer*)new MemTransferAndroid();
 #else
         instance = (MemTransfer*)new MemTransfer();
@@ -53,11 +45,9 @@ MemTransfer* MemTransferFactory::createInstance() {
 }
 
 bool MemTransferFactory::tryEnablePlatformOptimizations() {
-#ifdef OGLES_GPGPU_IOS
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
     usePlatformOptimizations = MemTransferIOS::initPlatformOptimizations();
-#elif OGLES_GPGPU_OSX
-    usePlatformOptimizations = MemTransferOSX::initPlatformOptimizations();
-#elif OGLES_GPGPU_ANDROID
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
     usePlatformOptimizations = MemTransferAndroid::initPlatformOptimizations();
 #else
     usePlatformOptimizations = false;

--- a/ogles_gpgpu/common/proc/base/filterprocbase.cpp
+++ b/ogles_gpgpu/common/proc/base/filterprocbase.cpp
@@ -204,14 +204,12 @@ void FilterProcBase::filterRenderPrepare() {
     // set the viewport
     glViewport(0, 0, outFrameW, outFrameH);
 
-    glClear(GL_COLOR_BUFFER_BIT);
-
     assert(texTarget == GL_TEXTURE_2D); // texTarget = GL_TEXTURE_2D;
 
     // set input texture
     glActiveTexture(GL_TEXTURE0 + texUnit);
     glBindTexture(texTarget, texId); // bind input texture
-
+    
     // set common uniforms
     glUniform1i(shParamUInputTex, texUnit);
 }

--- a/ogles_gpgpu/common/proc/base/procbase.h
+++ b/ogles_gpgpu/common/proc/base/procbase.h
@@ -240,7 +240,7 @@ protected:
 
     bool willDownscale; // is true if output size < input size.
 
-    GLenum inputDataFmt; // input pixel data format
+    GLenum inputDataFmt = 0; // input pixel data format
 
     int inFrameW = 0; // input frame width
     int inFrameH = 0; // input frame height

--- a/ogles_gpgpu/common/proc/three.cpp
+++ b/ogles_gpgpu/common/proc/three.cpp
@@ -115,8 +115,6 @@ void ThreeInputProc::filterRenderPrepare() {
     // set the viewport
     glViewport(0, 0, outFrameW, outFrameH);
 
-    glClear(GL_COLOR_BUFFER_BIT);
-
     // Bind input texture 1:
     glActiveTexture(GL_TEXTURE0 + texUnit);
     glBindTexture(texTarget, texId);

--- a/ogles_gpgpu/common/proc/two.cpp
+++ b/ogles_gpgpu/common/proc/two.cpp
@@ -104,8 +104,6 @@ void TwoInputProc::filterRenderPrepare() {
     // set the viewport
     glViewport(0, 0, outFrameW, outFrameH);
 
-    glClear(GL_COLOR_BUFFER_BIT);
-
     // Bind input texture 1:
     glActiveTexture(GL_TEXTURE0 + texUnit);
     glBindTexture(texTarget, texId);

--- a/ogles_gpgpu/common/proc/yuv2rgb.cpp
+++ b/ogles_gpgpu/common/proc/yuv2rgb.cpp
@@ -40,42 +40,56 @@ GLfloat* kColorConversion601 = kColorConversion601Default;
 GLfloat* kColorConversion601FullRange = kColorConversion601FullRangeDefault;
 GLfloat* kColorConversion709 = kColorConversion709Default;
 
-void setColorConversion601(GLfloat conversionMatrix[9]) {
-    kColorConversion601 = conversionMatrix;
-}
-
-void setColorConversion601FullRange(GLfloat conversionMatrix[9]) {
-    kColorConversion601FullRange = conversionMatrix;
-}
-
-void setColorConversion709(GLfloat conversionMatrix[9]) {
-    kColorConversion709 = conversionMatrix;
-}
-
 // clang-format off
-const char *kGPUImageYUVVideoRangeConversionForRGFragmentShaderString = 
+const char *kGPUImageYUVFullRangeConversionForRGFragmentShaderString =
 #if defined(OGLES_GPGPU_OPENGLES)
 OG_TO_STR(precision mediump float;)
 #endif
 OG_TO_STR(
           
- varying vec2 vTexCoord;
+  varying vec2 vTexCoord;
+  
+  uniform sampler2D luminanceTexture;
+  uniform sampler2D chrominanceTexture;
+  uniform mat3 colorConversionMatrix;
+  
+  void main()
+  {
+      vec3 yuv;
+      vec3 rgb;
+      
+      yuv.x = texture2D(luminanceTexture, vTexCoord).r;
+      yuv.yz = texture2D(chrominanceTexture, vTexCoord).rg - vec2(0.5, 0.5);
+      rgb = colorConversionMatrix * yuv;
+      
+      gl_FragColor = vec4(rgb, 1);
+  });
+// clang-format on
 
- uniform sampler2D luminanceTexture;
- uniform sampler2D chrominanceTexture;
- uniform mat3 colorConversionMatrix;
-
- void main()
- {
-     vec3 yuv;
-     vec3 rgb;
-
-     yuv.x = texture2D(luminanceTexture, vTexCoord).r;
-     yuv.yz = texture2D(chrominanceTexture, vTexCoord).rg - vec2(0.5, 0.5);
-     rgb = colorConversionMatrix * yuv;
-
-     gl_FragColor = vec4(rgb, 1);
- });
+// clang-format off
+const char *kGPUImageYUVVideoRangeConversionForRGFragmentShaderString =
+#if defined(OGLES_GPGPU_OPENGLES)
+OG_TO_STR(precision mediump float;)
+#endif
+OG_TO_STR(
+          
+  varying vec2 vTexCoord;
+  
+  uniform sampler2D luminanceTexture;
+  uniform sampler2D chrominanceTexture;
+  uniform mat3 colorConversionMatrix;
+  
+  void main()
+  {
+      vec3 yuv;
+      vec3 rgb;
+      
+      yuv.x = texture2D(luminanceTexture, vTexCoord).r - (16.0/255.0);
+      yuv.yz = texture2D(chrominanceTexture, vTexCoord).rg - vec2(0.5, 0.5);
+      rgb = colorConversionMatrix * yuv;
+      
+      gl_FragColor = vec4(rgb, 1);
+  });
 // clang-format on
 
 // clang-format off
@@ -126,14 +140,23 @@ OG_TO_STR(
      yuv.yz = texture2D(chrominanceTexture, vTexCoord).ra - vec2(0.5, 0.5);
      rgb = colorConversionMatrix * yuv;
 
-     gl_FragColor = vec4(rgb, 1);
+     gl_FragColor = vec4(rgb, 1);          
  });
 // clang-format on
 
 // =================================================================================
 
-Yuv2RgbProc::Yuv2RgbProc() {
-    _preferredConversion = kColorConversion601FullRange;
+
+
+Yuv2RgbProc::Yuv2RgbProc(YUVKind yuvKind, ChannelKind channelKind)
+    : yuvKind(yuvKind)
+    , channelKind(channelKind)
+{
+    switch(yuvKind) {
+        case k601VideoRange: _preferredConversion = kColorConversion601; break;
+        case k601FullRange: _preferredConversion = kColorConversion601FullRange; break;
+        case k709Default: _preferredConversion = kColorConversion709; break;
+    }
 
     texTarget = GL_TEXTURE_2D;
 }
@@ -144,7 +167,6 @@ void Yuv2RgbProc::setTextures(GLuint luminance, GLuint chrominance) {
 }
 
 void Yuv2RgbProc::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target) {
-    //FilterProcBase::filterShaderSetup(vShaderSrc, fShaderSrc, target);
 
     ProcBase::createShader(vShaderSrc, fShaderSrc, target);
     Tools::checkGLErr(getProcName(), "createShader()");
@@ -174,8 +196,33 @@ int Yuv2RgbProc::init(int inW, int inH, unsigned int order, bool prepareForExter
     baseInit(inW, inH, order, prepareForExternalInput, procParamOutW, procParamOutH, procParamOutScale);
 
     // FilterProcBase init - create shaders, get shader params, set buffers for OpenGL
-    filterInit(FilterProcBase::vshaderDefault, kGPUImageYUVFullRangeConversionForLAFragmentShaderString);
 
+    switch(channelKind) {
+    case kRG:
+        switch(yuvKind) {
+        case k601VideoRange:
+            filterInit(FilterProcBase::vshaderDefault, kGPUImageYUVVideoRangeConversionForRGFragmentShaderString);
+            break;
+        case k601FullRange:
+        case k709Default:
+            filterInit(FilterProcBase::vshaderDefault, kGPUImageYUVFullRangeConversionForRGFragmentShaderString);                
+            break;
+        }
+        break;
+            
+    case kLA:
+        switch(yuvKind) {
+        case k601VideoRange:
+            filterInit(FilterProcBase::vshaderDefault, kGPUImageYUVVideoRangeConversionForLAFragmentShaderString);
+            break;
+        case k601FullRange:
+        case k709Default:
+            filterInit(FilterProcBase::vshaderDefault, kGPUImageYUVFullRangeConversionForLAFragmentShaderString);                
+            break;
+        }
+        break;            
+    }
+    
     return 1;
 }
 
@@ -184,9 +231,6 @@ void Yuv2RgbProc::filterRenderPrepare() {
 
     // set the viewport
     glViewport(0, 0, outFrameW, outFrameH);
-
-    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     glActiveTexture(GL_TEXTURE4);
     glBindTexture(GL_TEXTURE_2D, luminanceTexture);

--- a/ogles_gpgpu/common/proc/yuv2rgb.h
+++ b/ogles_gpgpu/common/proc/yuv2rgb.h
@@ -23,10 +23,22 @@ namespace ogles_gpgpu {
  */
 class Yuv2RgbProc : public FilterProcBase {
 public:
+
+    enum ChannelKind {
+        kLA, // typically ES 2.0
+        kRG, // typically ES 3.0
+    };
+    
+    enum YUVKind {
+        k601VideoRange,
+        k601FullRange,
+        k709Default
+    };
+    
     /**
      * Constructor.
      */
-    Yuv2RgbProc();
+    Yuv2RgbProc(YUVKind yuvKind=k601VideoRange, ChannelKind channelKind=kLA);
 
     /**
      * Return the processors name.
@@ -59,8 +71,6 @@ private:
     static const char* vshaderYuv2RgbSrc; // fragment shader source
     static const char* fshaderYuv2RgbSrc; // fragment shader source
 
-    //GLProgram *yuvConversionProgram;
-
     GLuint luminanceTexture;
     GLuint chrominanceTexture;
 
@@ -72,6 +82,9 @@ private:
     GLint yuvConversionMatrixUniform;
 
     const GLfloat* _preferredConversion;
+
+    YUVKind yuvKind = k601VideoRange;
+    ChannelKind channelKind = kLA;
 };
 }
 

--- a/ogles_gpgpu/platform/android/gl_includes.h
+++ b/ogles_gpgpu/platform/android/gl_includes.h
@@ -11,5 +11,4 @@
  * OpenGL ES 2.0 includes for Android.
  */
 
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
+#include "../opengl/gl_includes.h"

--- a/ogles_gpgpu/platform/ios/gl_includes.h
+++ b/ogles_gpgpu/platform/ios/gl_includes.h
@@ -11,5 +11,4 @@
  * OpenGL ES 2.0 includes for iOS.
  */
 
-#include <OpenGLES/ES2/gl.h>
-#include <OpenGLES/ES2/glext.h>
+#include "../opengl/gl_includes.h"

--- a/ogles_gpgpu/platform/opengl/gl_includes.h
+++ b/ogles_gpgpu/platform/opengl/gl_includes.h
@@ -11,6 +11,9 @@
  * OpenGL (not iOS or Android) : handle all
  */
 
+#ifndef OGLES_GPGPU_OPENGL_GL_INCLUDES
+#define OGLES_GPGPU_OPENGL_GL_INCLUDES
+
 // clang-format off
 
 //define something for Windows (64-bit)
@@ -19,27 +22,41 @@
 #  include <windows.h> // CMakeLists.txt defines NOMINMAX
 #  include <gl/glew.h>
 #  include <GL/gl.h>
-#  include <GL/glu.h>
 #elif __APPLE__
 #  include "TargetConditionals.h"
 #  if (TARGET_OS_IPHONE && TARGET_IPHONE_SIMULATOR) || TARGET_OS_IPHONE
-#    include <OpenGLES/ES2/gl.h>
-#    include <OpenGLES/ES2/glext.h>
+#    if defined(OGLES_GPGPU_OPENGL_ES3)
+#      include <OpenGLES/ES3/gl.h>
+#      include <OpenGLES/ES3/glext.h>
+#    else
+#      include <OpenGLES/ES2/gl.h>
+#      include <OpenGLES/ES2/glext.h>
+#    endif
 #  else
-#    include <OpenGL/gl.h>
-#    include <OpenGL/glu.h>
-#    include <OpenGL/glext.h>
+#    if defined(OGLES_GPGPU_OPENGL_ES3)
+#      include <OpenGL/gl3.h>
+#      include <OpenGL/gl3ext.h>
+#    else
+#      include <OpenGL/gl.h>
+#      include <OpenGL/glext.h>
+#    endif
 #  endif
 #elif defined(__ANDROID__) || defined(ANDROID)
-#  include <GLES2/gl2.h>
-#  include <GLES2/gl2ext.h>
+#  if defined(OGLES_GPGPU_OPENGL_ES3)
+#    include <GLES3/gl3.h>
+#    include <GLES3/gl3ext.h>
+#  else
+#    include <GLES2/gl2.h>
+#    include <GLES2/gl2ext.h>
+#  endif
 #elif defined(__linux__) || defined(__unix__) || defined(__posix__)
 #  define GL_GLEXT_PROTOTYPES 1
 #  include <GL/gl.h>
-#  include <GL/glu.h>
 #  include <GL/glext.h>
 #else
 #  error platform not supported.
 #endif
 
 // clang-format on
+
+#endif // OGLES_GPGPU_OPENGL_GL_INCLUDES

--- a/ogles_gpgpu/platform/sugar.cmake
+++ b/ogles_gpgpu/platform/sugar.cmake
@@ -11,15 +11,27 @@ endif()
 
 include(sugar_include)
 
-if(IOS)
-  sugar_include(ios)
-elseif(APPLE)
-  sugar_include(osx)
-elseif(ANDROID)
-  sugar_include(android)
+if(ANDROID OR IOS)
+  set(ogles_gpgpu_is_mobile TRUE)
 else()
-  message("include opengl platforms.............")
+  set(ogles_gpgpu_is_mobile FALSE)
+endif()
+
+# We will use the vanilla OpenGL implementation in case
+# of standard OpenGL platforms (i.e., not OpenGL ES) or
+# in cases where >= OpenGL ES 3.0 is available.  On those
+# platforms we can use PBO for efficient GPU->CPU reads.
+# If we are using OpenGL ES 2.0 on mobile devices then
+# we will use platform specific extensions to facilitate
+# efficient DMA reads of OpenGL textures.
+if(OGLES_GPGPU_OPENGL_ES3 OR NOT ${ogles_gpgpu_is_mobile})
   sugar_include(opengl)
+else()
+  if(IOS)
+    sugar_include(ios)
+  elseif(ANDROID)
+    sugar_include(android )
+  endif()
 endif()
 
 

--- a/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
+++ b/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
@@ -1,3 +1,7 @@
+#ifdef NDEBUG
+#  undef NDEBUG
+#endif
+
 #include <aglet/aglet.h>
 #include <aglet/GLContext.h>
 
@@ -14,6 +18,8 @@
 #  define TEXTURE_FORMAT GL_BGRA
 #endif
 // clang-format off
+
+#define OGLES_GPGPU_DEBUG_YUV 1
 
 #include "../common/gl/memtransfer_optimized.h"
 
@@ -67,16 +73,25 @@ int gauze_main(int argc, char** argv) {
 }
 
 struct GLTexture {
-    GLTexture(std::size_t width, std::size_t height, GLenum texType, void* data) {
+    GLTexture(std::size_t width, std::size_t height, GLenum texType, void* data, GLint texFormat = GL_RGBA) {
         glGenTextures(1, &texId);
+        assert(glGetError() == GL_NO_ERROR);
+
         glBindTexture(GL_TEXTURE_2D, texId);
+        assert(glGetError() == GL_NO_ERROR);
+
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        assert(glGetError() == GL_NO_ERROR);
+        
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, texType, GL_UNSIGNED_BYTE, data);
+        glTexImage2D(GL_TEXTURE_2D, 0, texFormat, width, height, 0, texType, GL_UNSIGNED_BYTE, data);
+        assert(glGetError() == GL_NO_ERROR);
+        
         glBindTexture(GL_TEXTURE_2D, 0);
+        assert(glGetError() == GL_NO_ERROR);
     }
 
     ~GLTexture() {
@@ -103,7 +118,7 @@ static cv::Mat getImage(ogles_gpgpu::ProcInterface& proc, cv::Mat& frame) {
     return frame;
 }
 
-static cv::Mat getTestImage(int width, int height, int stripe, bool alpha) {
+static cv::Mat getTestImage(int width, int height, int stripe, bool alpha, GLenum format) {
     // Create a test image:
     cv::Mat test(height, width, CV_8UC3, cv::Scalar::all(0));
     cv::Point center(test.cols / 2, test.rows / 2);
@@ -111,9 +126,14 @@ static cv::Mat getTestImage(int width, int height, int stripe, bool alpha) {
         cv::circle(test, center, i, cv::Scalar(rand() % 255, rand() % 255, rand() % 255), -1, 8);
     }
 
+    if(format == GL_RGBA /* or GL_RGB */ ) {
+        cv::cvtColor(test, test, cv::COLOR_BGR2RGB);
+    }
+    
     if (alpha) {
         cv::cvtColor(test, test, cv::COLOR_BGR2BGRA); // add alpha
     }
+    
     return test;
 }
 
@@ -123,94 +143,183 @@ static cv::Mat getTestImage(int width, int height, int stripe, bool alpha) {
 
 static int gWidth = 640;
 static int gHeight = 480;
+static aglet::GLContext::GLVersion gVersion = aglet::GLContext::kGLES30;
 
-#if !defined(_WIN32) && !defined(_WIN64)
-// vs-14-2015 GLSL reports the following error due to internal preprocessor #define
-// > could not compile shader program.  error log:
-// > 0:1(380): preprocessor error: syntax error, unexpected HASH_TOKEN
-TEST(OGLESGPGPUTest, MedianProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+TEST(OGLESGPGPUTest, WriteAndRead) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    if(context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 20, true);
-
+    if (context && *context) {
+        cv::Mat test = getTestImage(gWidth, gHeight, 10, true, TEXTURE_FORMAT);
         glActiveTexture(GL_TEXTURE0);
-        ogles_gpgpu::VideoSource video;
-        ogles_gpgpu::MedianProc median;
 
-        video.set(&median);
+        ogles_gpgpu::GainProc gain;
+        auto *filter = dynamic_cast<ogles_gpgpu::ProcInterface *>(&gain);
+        
+        static const bool prepareForExternalInput = true;
+        
+        // Set pixel data format for input data to <fmt>. Must be set before init() / reinit().
+        filter->setExternalInputDataFormat(TEXTURE_FORMAT);
 
-        cv::Mat noise = cv::Mat::zeros(test.rows, test.cols, CV_8UC1);
-        cv::randu(noise, 0, 255);
-        test.setTo(0, noise < 30);
-        test.setTo(255, noise > 225);
+        // Init the processor for input frames of size <inW>x<inH> which is at position <order>
+        // in the processing pipeline.
+        filter->init(test.cols, test.rows, 0, prepareForExternalInput);
+        
+        // Insert external data into this processor. It will be used as input texture.
+        // Note: init() must have been called with prepareForExternalInput = true for that.
+        filter->setExternalInputData(test.ptr<std::uint8_t>());
+        
+        // Createa and bind an output FBO + texture.
+        filter->createFBOTex(false);
+        
+        // Notify the MemTransfer object that we are using raw data, as opposed to
+        // platform specific image types (i.e., CMSampleBuffer)
+        filter->getInputMemTransferObj()->setUseRawPixels(true);
 
-        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
-
+        // Perform off screen rendering to output FBO:
+        gain.render();
+        
         cv::Mat result;
-        getImage(median, result);
-        ASSERT_FALSE(result.empty());
+        getImage(gain, result);
+
+        /*
+        std::cout << cv::mean(result) << " vs " << cv::mean(test) << std::endl;
+         
+        cv::Mat delta;
+        cv::absdiff(result, test, delta);
+
+        std::vector<cv::Mat> channels;
+        cv::split(delta, channels);
+        delta = cv::max(cv::max(channels[0], channels[1]), channels[2]);
+
+        std::vector<cv::Point> points;
+        cv::findNonZero(delta, points);
+        for(const auto &p : points)
+        {
+            std::cout << p << " " << int(delta.at<std::uint8_t>(p)) << std::endl;
+        }
+        */
+        
+        auto almost_equal = [](const cv::Vec4b &a, const cv::Vec4b &b)
+        {
+            int delta = std::abs(static_cast<int>(a[0]) - static_cast<int>(b[0]));
+            if(delta > 2)
+            {
+                return false;
+            }
+            return true;
+        };        
+        
+        ASSERT_TRUE(std::equal(test.begin<cv::Vec4b>(), test.end<cv::Vec4b>(), result.begin<cv::Vec4b>(), almost_equal));
     }
 }
-#endif
 
-#if !defined(ANDROID)
-// glTexImage2D w/ GL_LUMINANCE or GL_LUMINANCE_ALPHA report error 1282 in tests w/ android-ndk-r10e-api-19
-// TODO: The GL_RED_EXT seems to be available in >= android-21
 TEST(OGLESGPGPUTest, Yuv2RgbProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();    
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        static const int width = 640, height = 480;
 
         cv::Mat green(1, 1, CV_8UC3, cv::Scalar(0, 255, 0)), yuv;
         cv::cvtColor(green, yuv, cv::COLOR_BGR2YUV);
         cv::Vec3b& value = yuv.at<cv::Vec3b>(0, 0);
 
         // Create constant color buffers:
-        std::vector<std::uint8_t> y(width * height, value[0]), uv(width * height / 2);
+        std::vector<std::uint8_t> y(gWidth * gHeight, value[0]), uv(gWidth * gHeight / 2);
         for (int i = 0; i < uv.size(); i += 2) {
             uv[i + 0] = value[1];
             uv[i + 1] = value[2];
         }
 
+#if defined(OGLES_GPGPU_OPENGL_ES3)
         // Luminance texture:
-        GLTexture luminanceTexture(gWidth, gHeight, GL_LUMINANCE, y.data());
+        GLTexture luminanceTexture(gWidth, gHeight, GL_RED, y.data(), GL_R8);
         ASSERT_EQ(glGetError(), GL_NO_ERROR);
+        std::cout << "ES3 k601VideoRange kRG" << std::endl;
 
         // Chrominance texture (interleaved):
-        GLTexture chrominanceTexture(width / 2, height / 2, GL_LUMINANCE_ALPHA, uv.data());
+        GLTexture chrominanceTexture(gWidth / 2, gHeight / 2, GL_RG, uv.data(), GL_RG8);
         ASSERT_EQ(glGetError(), GL_NO_ERROR);
+        
+        ogles_gpgpu::Yuv2RgbProc yuv2rgb(ogles_gpgpu::Yuv2RgbProc::k601VideoRange, ogles_gpgpu::Yuv2RgbProc::kRG);
+#else
+        // Luminance texture:
+        GLTexture luminanceTexture(gWidth, gHeight, GL_LUMINANCE, y.data(), GL_LUMINANCE);
+        ASSERT_EQ(glGetError(), GL_NO_ERROR);
+        std::cout << "ES2 k601VideoRange kLA" << std::endl;
 
-        ogles_gpgpu::Yuv2RgbProc yuv2rgb;
-        yuv2rgb.init(gWidth, gHeight, 0, true);
+        // Chrominance texture (interleaved):
+        GLTexture chrominanceTexture(gWidth / 2, gHeight / 2, GL_LUMINANCE_ALPHA, uv.data(), GL_LUMINANCE_ALPHA);
+        ASSERT_EQ(glGetError(), GL_NO_ERROR);
+        
+        ogles_gpgpu::Yuv2RgbProc yuv2rgb(ogles_gpgpu::Yuv2RgbProc::k601VideoRange, ogles_gpgpu::Yuv2RgbProc::kLA);
+#endif
+
+        // Set pixel data format for input data to <fmt>. Must be set before init() / reinit().
         yuv2rgb.setExternalInputDataFormat(0); // for yuv
+        
+        // Init the processor for input frames of size <inW>x<inH> which is at position <order>
+        // in the processing pipeline.
+        yuv2rgb.init(gWidth, gHeight, 0, true);
+        
+        // Be sure to specify stanrdard (GL_RGBA) output texture type
+        // for this case where input textures == 0 are handled as special
+        // separate Y and UV textures.
         yuv2rgb.getMemTransferObj()->setOutputPixelFormat(TEXTURE_FORMAT);
+        
+        // Create an FBO
         yuv2rgb.createFBOTex(false);
+        
+        // Provide the input Y and UV textures:
         yuv2rgb.setTextures(luminanceTexture, chrominanceTexture);
+        
+        // Perform the rendering
         yuv2rgb.render();
 
         cv::Mat result;
         getImage(yuv2rgb, result);
         ASSERT_FALSE(result.empty());
-
-        //auto mu = cv::mean(result);
-        //ASSERT_EQ(mu[0], 0);
-        //ASSERT_EQ(mu[1], 255);
-        //ASSERT_EQ(mu[2], 0);
+        
+        auto mu = cv::mean(result);
+        
+#if OGLES_GPGPU_DEBUG_YUV
+        ogles_gpgpu::GainProc yProc;
+        yProc.prepare(gWidth, gHeight);
+        yProc.process(luminanceTexture, 1, GL_TEXTURE_2D);
+        cv::Mat yProcOut;
+        getImage(yProc, yProcOut);
+        
+        ogles_gpgpu::GainProc uvProc;
+        uvProc.prepare(gWidth, gHeight);
+        uvProc.process(chrominanceTexture, 1, GL_TEXTURE_2D);
+        cv::Mat uvProcOut;
+        getImage(uvProc, uvProcOut);
+        
+        std::cout << "yuv_in  : " << value << std::endl;
+        std::cout << "rgb_out : " << mu << std::endl;
+        std::cout << "y_      : " << cv::mean(yProcOut) << std::endl;
+        std::cout << "uv_     : " << cv::mean(uvProcOut) << std::endl;
+        std::cout << "Format: " << int(yProc.getMemTransferObj()->getOutputPixelFormat()) << std::endl;
+#endif // OGLES_GPGPU_DEBUG_YUV
+        
+        ASSERT_LE(mu[0], 8);
+        ASSERT_GE(mu[1], 250);
+        ASSERT_LE(mu[2], 8);
     }
 }
-#endif
 
 TEST(OGLESGPGPUTest, GrayScaleProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 10, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 10, true, TEXTURE_FORMAT);
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::GrayscaleProc gray;
+
+        gray.setGrayscaleConvType(ogles_gpgpu::GRAYSCALE_INPUT_CONVERSION_RGB);
 
         video.set(&gray);
         video({ { test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT });
@@ -218,15 +327,35 @@ TEST(OGLESGPGPUTest, GrayScaleProc) {
         cv::Mat result;
         getImage(gray, result);
         ASSERT_FALSE(result.empty());
+        
+        cv::Mat truth;
+        cv::cvtColor(test, truth, (TEXTURE_FORMAT == GL_RGBA) ? cv::COLOR_RGBA2GRAY : cv::COLOR_BGRA2GRAY);
+
+        std::cout << cv::mean(truth) << " vs " << cv::mean(result) << std::endl;
+        
+        // clang-off
+        auto almost_equal = [](const cv::Vec4b &a, const cv::Vec4b &b)
+        {
+            int delta = std::abs(static_cast<int>(a[0]) - static_cast<int>(b[0]));
+            if(delta > 2)
+            {
+                //std::cout << "delta: " << delta << std::endl;
+                return false;
+            }
+            return true;
+        };
+        ASSERT_TRUE(std::equal(truth.begin<cv::Vec4b>(), truth.end<cv::Vec4b>(), result.begin<cv::Vec4b>(), almost_equal));
+        // clang-on
     }
 }
 
 TEST(OGLESGPGPUTest, AdaptThreshProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 10, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 10, true, TEXTURE_FORMAT);
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::AdaptThreshProc thresh;
@@ -241,12 +370,13 @@ TEST(OGLESGPGPUTest, AdaptThreshProc) {
 }
 
 TEST(OGLESGPGPUTest, GainProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
         static const int value = 1, g = 10;
-        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value, value, value, 255));
+        cv::Mat test(gWidth, gHeight, CV_8UC4, cv::Scalar(value, value, value, 255));
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -262,14 +392,15 @@ TEST(OGLESGPGPUTest, GainProc) {
 }
 
 TEST(OGLESGPGPUTest, BlendProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
         const float alpha = 0.5f;
         const int value = 2;
         const int a = 1, b = 10;
-        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value, value, value, 255));
+        cv::Mat test(gWidth, gHeight, CV_8UC4, cv::Scalar(value, value, value, 255));
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -290,7 +421,8 @@ TEST(OGLESGPGPUTest, BlendProc) {
 }
 
 TEST(OGLESGPGPUTest, FIFOProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
@@ -300,7 +432,7 @@ TEST(OGLESGPGPUTest, FIFOProc) {
         video.set(&fifo);
 
         for (int i = 0; i < 3; i++) {
-            cv::Mat test(640, 480, CV_8UC4, cv::Scalar(i, i, i, 255));
+            cv::Mat test(gWidth, gHeight, CV_8UC4, cv::Scalar(i, i, i, 255));
             video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
         }
 
@@ -313,7 +445,8 @@ TEST(OGLESGPGPUTest, FIFOProc) {
 }
 
 TEST(OGLESGPGPUTest, TransformProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
@@ -336,7 +469,7 @@ TEST(OGLESGPGPUTest, TransformProc) {
 
         transform.setTransformMatrix(matrix);
 
-        cv::Mat test = getTestImage(640, 480, 10, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 10, true, TEXTURE_FORMAT);
         video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
@@ -346,13 +479,14 @@ TEST(OGLESGPGPUTest, TransformProc) {
 }
 
 TEST(OGLESGPGPUTest, DiffProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
         const int value = 2;
         const int a = 1, b = 10;
-        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value, value, value, 255));
+        cv::Mat test(gWidth, gHeight, CV_8UC4, cv::Scalar(value, value, value, 255));
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -373,11 +507,12 @@ TEST(OGLESGPGPUTest, DiffProc) {
 }
 
 TEST(OGLESGPGPUTest, GaussianProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 1, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 1, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -394,11 +529,12 @@ TEST(OGLESGPGPUTest, GaussianProc) {
 }
 
 TEST(OGLESGPGPUTest, GaussianOptProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 1, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 1, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -414,11 +550,12 @@ TEST(OGLESGPGPUTest, GaussianOptProc) {
 }
 
 TEST(OGLESGPGPUTest, BoxOptProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 1, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 1, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -434,7 +571,8 @@ TEST(OGLESGPGPUTest, BoxOptProc) {
 }
 
 TEST(OGLESGPGPUTest, HessianProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
@@ -465,11 +603,12 @@ TEST(OGLESGPGPUTest, HessianProc) {
 }
 
 TEST(OGLESGPGPUTest, LbpProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 1, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 1, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -485,11 +624,12 @@ TEST(OGLESGPGPUTest, LbpProc) {
 }
 
 TEST(OGLESGPGPUTest, Fir3Proc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        const cv::Size size(640, 480);
+        const cv::Size size(gWidth, gHeight);
         const cv::Point center(size.width / 2, size.height / 2);
         const float radius = size.height / 2;
 
@@ -530,11 +670,12 @@ TEST(OGLESGPGPUTest, Fir3Proc) {
 }
 
 TEST(OGLESGPGPUTest, GradProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -550,7 +691,8 @@ TEST(OGLESGPGPUTest, GradProc) {
 }
 
 TEST(OGLESGPGPUTest, LowPassProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
@@ -576,7 +718,8 @@ TEST(OGLESGPGPUTest, LowPassProc) {
 }
 
 TEST(OGLESGPGPUTest, HighPassProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
@@ -602,11 +745,12 @@ TEST(OGLESGPGPUTest, HighPassProc) {
 }
 
 TEST(OGLESGPGPUTest, ThreshProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -622,11 +766,12 @@ TEST(OGLESGPGPUTest, ThreshProc) {
 }
 
 TEST(OGLESGPGPUTest, PyramidProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -642,7 +787,8 @@ TEST(OGLESGPGPUTest, PyramidProc) {
 }
 
 TEST(OGLESGPGPUTest, IxytProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
@@ -659,7 +805,7 @@ TEST(OGLESGPGPUTest, IxytProc) {
         fifo.addWithDelay(&ixyt, 0, 0);
 
         for (int i = 0; i < 5; i++) {
-            cv::Mat test = getTestImage(640, 480, 2, true);
+            cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
             video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
         }
 
@@ -674,11 +820,12 @@ TEST(OGLESGPGPUTest, IxytProc) {
 }
 
 TEST(OGLESGPGPUTest, TensorProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -694,11 +841,12 @@ TEST(OGLESGPGPUTest, TensorProc) {
 }
 
 TEST(OGLESGPGPUTest, ShiTomasiProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
         for (int i = 0; i < 100; i++) {
             cv::Point p0(rand() % test.cols, rand() % test.rows);
             cv::Point p1(rand() % test.cols, rand() % test.rows);
@@ -727,11 +875,12 @@ TEST(OGLESGPGPUTest, ShiTomasiProc) {
 }
 
 TEST(OGLESGPGPUTest, HarrisProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
         for (int i = 0; i < 100; i++) {
             cv::Point p0(rand() % test.cols, rand() % test.rows);
             cv::Point p1(rand() % test.cols, rand() % test.rows);
@@ -760,7 +909,8 @@ TEST(OGLESGPGPUTest, HarrisProc) {
 }
 
 TEST(OGLESGPGPUTest, NmsProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
@@ -793,11 +943,12 @@ TEST(OGLESGPGPUTest, NmsProc) {
 }
 
 TEST(OGLESGPGPUTest, FlowProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -821,11 +972,12 @@ TEST(OGLESGPGPUTest, FlowProc) {
 }
 
 TEST(OGLESGPGPUTest, Rgb2HsvProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -841,11 +993,12 @@ TEST(OGLESGPGPUTest, Rgb2HsvProc) {
 }
 
 TEST(OGLESGPGPUTest, Hsv2RgbProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -861,11 +1014,12 @@ TEST(OGLESGPGPUTest, Hsv2RgbProc) {
 }
 
 TEST(OGLESGPGPUTest, LNormProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);    
     if (context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -881,3 +1035,35 @@ TEST(OGLESGPGPUTest, LNormProc) {
         ASSERT_FALSE(result.empty());
     }
 }
+
+#if !defined(_WIN32) && !defined(_WIN64)
+// vs-14-2015 GLSL reports the following error due to internal preprocessor #define
+// > could not compile shader program.  error log:
+// > 0:1(380): preprocessor error: syntax error, unexpected HASH_TOKEN
+TEST(OGLESGPGPUTest, MedianProc) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
+    ASSERT_TRUE(context && (*context));
+    if(context && *context) {
+        cv::Mat test = getTestImage(gWidth, gHeight, 20, true, TEXTURE_FORMAT);
+        
+        glActiveTexture(GL_TEXTURE0);
+        ogles_gpgpu::VideoSource video;
+        ogles_gpgpu::MedianProc median;
+        
+        video.set(&median);
+        
+        cv::Mat noise = cv::Mat::zeros(test.rows, test.cols, CV_8UC1);
+        cv::randu(noise, 0, 255);
+        test.setTo(0, noise < 30);
+        test.setTo(255, noise > 225);
+        
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
+        
+        cv::Mat result;
+        getImage(median, result);
+        ASSERT_FALSE(result.empty());
+    }
+}
+#endif
+


### PR DESCRIPTION
NOTE: This PR is ready for merging (assuming tests pass) once the aglet commit currently in GIT_SUBMODULE "3rdparty/aglet" is added upstream to hunter.

* use latest AGLET via hunter GIT_SUBMODULE (TODO: use package)
* set AGLET_OPENGL_ES3 == OGLES_GPGPU_OPENGL_ES3 for unit tests
* make build scripts support opengl es 3.0 or 2.0 via command line option
* add hunter related notes to CMakeLists.txt
* update Yuv2RgbProc unit test and shaders (add control for coefficients)
* add PBO input and output options to MemTransfer class when defined(OGLES_GPGPU_OPENGL_ES3)
* add WriteAndRead unit test (exercise ES 3.0 PBO input and output + standard glTexImage/glReadPixels + iOS and Android platform extensions)
* include master gl_includes.h for all-in-one gl platform definitions
* remove glu includes
* remove glClear (texture is unbound) in filterRenderPrepare()
* add FindOpengLES3.cmake for android
* add additional test conditions to shader tests (grayscale, etc)