### PR TITLE
add opengl es 3.0 support w/ {I,O}PBO based pixel trasfers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,12 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-  URL "https://github.com/ruslo/hunter/archive/v0.19.29.tar.gz"
-  SHA1 "b0a69cd79597493f5e1e32d4cb77ff764807618a"  
-  LOCAL
-  )
+  URL "https://github.com/ruslo/hunter/archive/v0.19.36.tar.gz"
+  SHA1 "db6f5483795c56968fe628b3cc9791ec6627bdfc"
+  LOCAL  
+)
 
-project(ogles_gpgpu VERSION 0.2.0)
+project(ogles_gpgpu VERSION 0.2.1)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -23,6 +23,11 @@ option(OGLES_GPGPU_INSTALL "Perform installation" ON)
 option(OGLES_GPGPU_VERBOSE "Perform per filter logging" OFF)
 option(OGLES_GPGPU_BUILD_TESTS "Build shader unit tests" OFF)
 option(OGLES_GPGPU_USE_OSMESA "Use MESA CPU OpenGL (via glfw)" OFF)
+
+# !!! Make sure option OGLES_GPGPU_OPENG_ES3 occurs prior to the first
+# hunter_add_package() call.  This will allow us to modify settings
+# in dependencies appropriately (see cmake/Hunter/config.cmake)
+option(OGLES_GPGPU_OPENGL_ES3 "Use OpenGL ES 3.0" OFF)
 
 # See: cmake/Hunter/config.cmake
 hunter_add_package(Sugar)

--- a/bin/build-android.sh
+++ b/bin/build-android.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
+CONFIG=Release
+
+OGLES_GPGPU_OPENGL_ES3="OFF"
+if [[ "$#" -gt 0 ]] ; then
+    OGLES_GPGPU_OPENGL_ES3="ON"
+fi
+
+ARGS=(
+    OGLES_GPGPU_BUILD_TESTS=ON
+    OGLES_GPGPU_OPENGL_ES3="${OGLES_GPGPU_OPENGL_ES3}"
+    HUNTER_CONFIGURATION_TYPES=${CONFIG}
+)
+
+polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --open --test --fwd ${ARGS[@]} --test

--- a/bin/build-ios.sh
+++ b/bin/build-ios.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+
+TOOLCHAIN=ios-10-1-arm64-dep-8-0-hid-sections
+CONFIG=Release
+
+echo "ARGC: ${#}"
+OGLES_GPGPU_OPENGL_ES3="OFF"
+if [[ "$#" -gt 0 ]] ; then
+    OGLES_GPGPU_OPENGL_ES3="ON"
+fi
+
+ARGS=(
+    OGLES_GPGPU_BUILD_TESTS=ON
+    OGLES_GPGPU_OPENGL_ES3=${OGLES_GPGPU_OPENGL_ES3}
+    HUNTER_CONFIGURATION_TYPES=${CONFIG}
+)
+
+polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --open --fwd ${ARGS[@]} --test
+
+
+

--- a/bin/build-libcxx.sh
+++ b/bin/build-libcxx.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+TOOLCHAIN=xcode
+CONFIG=Release
+
+OGLES_GPGPU_OPENGL_ES3="OFF"
+if [[ "$#" -gt 0 ]] ; then
+    OGLES_GPGPU_OPENGL_ES3="ON"
+fi
+
+ARGS=(
+    OGLES_GPGPU_BUILD_TESTS=ON
+    OGLES_GPGPU_OPENGL_ES3=${OGLES_GPGPU_OPENGL_ES3}
+    HUNTER_CONFIGURATION_TYPES=${CONFIG}
+)
+
+polly.py --toolchain ${TOOLCHAIN} --verbose --config ${CONFIG} --reconfig --test --fwd ${ARGS[@]} --test

--- a/bin/ogles_gpgpu-format.sh
+++ b/bin/ogles_gpgpu-format.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Note: When using clang-format the ${OGLES_GPGPU_ROOT}/.clang-format file
+# seems to be ignored if the root directory to this script is not
+# specified relative to the working directory:
+#
+# Suggested usage:
+#
+# cd ${OGLES_GPGPU_ROOT}
+# ./bin/ogles_gpgpu-format.sh lib
+# ./bin/ogles_gpgpu-format.sh test
+
+# Find all internal files, making sure to exlude 3rdparty subprojects
+function find_ogles_gpgpu_source()
+{
+    find $1 -name "*.h" -or -name "*.cpp" -or -name "*.hpp" -or -name "*.m" -or -name "*.mm"
+}
+
+input_dir=$1
+
+echo ${input_dir}
+
+find_ogles_gpgpu_source ${input_dir} | while read name
+do
+    echo $name
+    clang-format -i -style=file ${name}
+done
+
+

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -126,3 +126,16 @@ if(OGLES_GPGPU_USE_OSMESA)
   hunter_config(glfw VERSION ${HUNTER_glfw_VERSION} CMAKE_ARGS GLFW_USE_OSMESA=ON)
 endif()
 
+# Note: Aglet is currently used to provide an OpenGL context for the unit tests
+# We need to make sure it is configured appropriately to provide one of:
+# * OpenGL ES 3.0 (or OpenGL 3.0)
+# * OpenGL ES 2.0
+# The context must be allocated approprately and we need to pull in the correct
+# set of headers with mixing them.
+if(OGLES_GPGPU_OPENGL_ES3)
+  set(aglet_es3 ON)
+else()
+  set(aglet_es3 OFF)
+endif()
+
+hunter_config(aglet VERSION ${HUNTER_aglet_VERSION} CMAKE_ARGS AGLET_OPENGL_ES3=${aglet_es3})

--- a/cmake/modules/FindOpenGLES3.cmake
+++ b/cmake/modules/FindOpenGLES3.cmake
@@ -1,0 +1,7 @@
+#  Copyright 2010-2014 Matus Chochlik. Distributed under the Boost
+#  Software License, Version 1.0. (See accompanying file
+#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+include(CommonFindMod)
+ogles_gpgpu_common_find_module(OpenGLES3 GLESv3 GLES3/gl3.h GLESv3)

--- a/ogles_gpgpu/CMakeLists.txt
+++ b/ogles_gpgpu/CMakeLists.txt
@@ -32,8 +32,17 @@ elseif(ANDROID)
   find_package(Android REQUIRED)
   find_package(Log REQUIRED)
   find_package(EGL REQUIRED)
-  find_package(OpenGLES2 REQUIRED)
-  target_link_libraries(ogles_gpgpu PUBLIC log android EGL GLESv2)
+
+  if(OGLES_GPGPU_OPENGL_ES3)
+    find_package(OpenGLES3 REQUIRED)
+    set(ogles_gpgpu_opengl_lib GLESv3)
+  else()
+    find_package(OpenGLES2 REQUIRED)
+    set(ogles_gpgpu_opengl_lib GLESv2)
+  endif()
+  target_link_libraries(ogles_gpgpu PUBLIC log android EGL ${ogles_gpgpu_opengl_lib})
+
+  
   target_compile_definitions(ogles_gpgpu PUBLIC EGL_EGLEXT_PROTOTYPES GL_GLEXT_PROTOTYPES)
 else()
 
@@ -79,7 +88,11 @@ else()
     set_property(TARGET ogles_gpgpu_cpu PROPERTY FOLDER "libs/ogles_gpgpu")
     target_include_directories(
       ogles_gpgpu_cpu PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>"
-      )    
+      )
+
+    if(OGLES_GPGPU_OPENGL_ES3)    
+      target_compile_definitions(ogles_gpgpu_cpu PUBLIC OGLES_GPGPU_OPENGL_ES3=1)
+    endif()
     
   endif()
 
@@ -100,7 +113,11 @@ endif()
 set_property(TARGET ogles_gpgpu PROPERTY FOLDER "libs/ogles_gpgpu")
 target_include_directories(
     ogles_gpgpu PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>"
-)
+    )
+
+if(OGLES_GPGPU_OPENGL_ES3)    
+  target_compile_definitions(ogles_gpgpu PUBLIC OGLES_GPGPU_OPENGL_ES3=1)
+endif()
 
 ## #################################################################
 ## Testing: 

--- a/ogles_gpgpu/common/common_includes.h
+++ b/ogles_gpgpu/common/common_includes.h
@@ -30,18 +30,15 @@
 #  define OGLES_GPGPU_WINDOWS 1
 #endif
 
-#ifdef OGLES_GPGPU_IOS
-#  define OGLES_GPGPU_OPENGLES 1
+#include "../platform/opengl/gl_includes.h"
+
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
 #  include "../platform/ios/gl_includes.h"
 #  include "macros.h"
-#elif OGLES_GPGPU_ANDROID
-#  define OGLES_GPGPU_OPENGLES 1
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
 #  include "../platform/android/gl_includes.h"
 #  include "../platform/android/macros.h"
 #  include "../platform/android/egl.h"
-#elif OGLES_GPGPU_OSX
-#  include "../platform/osx/gl_includes.h"
-#  include "macros.h"
 #else
 #  define OGLES_GPGPU_OPENGL 1
 #  include "../platform/opengl/gl_includes.h"
@@ -49,16 +46,11 @@
 #endif
 // clang-format on
 
-/* #ifdef __APPLE__ */
-/*     #include "../platform/ios/gl_includes.h" */
-/* 	#include "macros.h" */
-/* #elif __ANDROID__ */
-/*     #include "../platform/android/gl_includes.h" */
-/* 	#include "../platform/android/macros.h" */
-/* 	#include "../platform/android/egl.h" */
-/* #else */
-/* #error platform not supported. either __APPLE__ or __ANDROID__ must be defined. */
-/* #endif */
+// clang-format off
+#if defined(OGLES_GPGPU_ANDROID) || defined(OGLES_GPGPU_IOS)
+#  define OGLES_GPGPU_OPENGLES 1
+#endif
+// clang-format on
 
 #define BEGIN_OGLES_GPGPU namespace ogles_gpgpu {
 #define END_OGLES_GPGPU }

--- a/ogles_gpgpu/common/gl/fbo.h
+++ b/ogles_gpgpu/common/gl/fbo.h
@@ -32,7 +32,7 @@ public:
     /**
      * Constructor.
      */
-    FBO();
+    FBO(bool doAlloc = true);
 
     /**
      * Deconstructor.
@@ -85,6 +85,11 @@ public:
     void unbind();
 
     /**
+     * Attach a pre-existing texture to the framebuffer.
+     */
+    virtual void attach(GLuint texId, GLenum attachment = GL_COLOR_ATTACHMENT0, GLenum target = GL_TEXTURE_2D);
+
+    /**
      * Will create a framebuffer output texture with texture id <attachedTexId>
      * and will bind it to this FBO.
      */
@@ -94,12 +99,12 @@ public:
      * Copy the framebuffer data which was written to the framebuffer texture back to
      * main memory at <buf>.
      */
-    virtual void readBuffer(unsigned char* buf);
+    virtual void readBuffer(unsigned char* buf, int index = 0);
 
     /**
      * Call the delegate on framebuffer data which was written to the framebuffer texture.
      */
-    virtual void readBuffer(FrameDelegate& delegate);
+    virtual void readBuffer(const FrameDelegate& delegate, int index = 0);
 
     /**
      * Free the framebuffer.
@@ -140,7 +145,7 @@ protected:
 
     Core* core; // Core singleton
 
-    MemTransfer* memTransfer; // MemTransfer object associated with this FBO
+    MemTransfer* memTransfer = nullptr; // MemTransfer object associated with this FBO
 
     GLuint id; // OpenGL FBO id
     GLuint glTexUnit; // GL texture unit (to be used in glActiveTexture()) for output texture

--- a/ogles_gpgpu/common/gl/memtransfer_factory.cpp
+++ b/ogles_gpgpu/common/gl/memtransfer_factory.cpp
@@ -10,21 +10,15 @@
 #include "memtransfer_factory.h"
 #include "../core.h"
 
-//#ifdef __APPLE__
-//#include "../../platform/ios/memtransfer_ios.h"
-//#elif __ANDROID__
-//#include "../../platform/android/memtransfer_android.h"
-//#endif
-
-#ifdef OGLES_GPGPU_IOS
-#include "../../platform/ios/memtransfer_ios.h"
-#elif OGLES_GPGPU_OSX
-#include "../../platform/osx/memtransfer_osx.h"
-#elif OGLES_GPGPU_ANDROID
-#include "../../platform/android/memtransfer_android.h"
+// clang-off
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
+#  include "../../platform/ios/memtransfer_ios.h"
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
+#  include "../../platform/android/memtransfer_android.h"
 #else
-#include "../../platform/opengl/memtransfer_generic.h"
+#  include "../../platform/opengl/memtransfer_generic.h"
 #endif
+// clang-on
 
 using namespace ogles_gpgpu;
 
@@ -34,11 +28,9 @@ MemTransfer* MemTransferFactory::createInstance() {
     MemTransfer* instance = NULL;
 
     if (usePlatformOptimizations) { // create specialized instance
-#ifdef OGLES_GPGPU_IOS
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
         instance = (MemTransfer*)new MemTransferIOS();
-#elif OGLES_GPGPU_OSX
-        instance = (MemTransfer*)new MemTransferOSX();
-#elif OGLES_GPGPU_ANDROID
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
         instance = (MemTransfer*)new MemTransferAndroid();
 #else
         instance = (MemTransfer*)new MemTransfer();
@@ -53,11 +45,9 @@ MemTransfer* MemTransferFactory::createInstance() {
 }
 
 bool MemTransferFactory::tryEnablePlatformOptimizations() {
-#ifdef OGLES_GPGPU_IOS
+#if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
     usePlatformOptimizations = MemTransferIOS::initPlatformOptimizations();
-#elif OGLES_GPGPU_OSX
-    usePlatformOptimizations = MemTransferOSX::initPlatformOptimizations();
-#elif OGLES_GPGPU_ANDROID
+#elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
     usePlatformOptimizations = MemTransferAndroid::initPlatformOptimizations();
 #else
     usePlatformOptimizations = false;

--- a/ogles_gpgpu/common/gl/pbo.cpp
+++ b/ogles_gpgpu/common/gl/pbo.cpp
@@ -1,0 +1,170 @@
+//
+// ogles_gpgpu project - GPGPU for mobile devices and embedded systems using OpenGL ES 2.0
+//
+// See LICENSE file in project repository root for the license.
+//
+
+// Copyright (c) 2017, David Hirvonen (this file)
+
+#include "pbo.h"
+#include "ogles_gpgpu/platform/opengl/gl_includes.h"
+
+#include <iostream>
+#include <sstream>
+
+#include <stdlib.h>
+
+using namespace std;
+using namespace ogles_gpgpu;
+
+// ::: input/read  :::
+
+IPBO::IPBO(std::size_t width, std::size_t height)
+    : width(width)
+    , height(height)
+    , isReadingAsynchronously_(false) {
+
+    glGenBuffers(1, &pbo);
+    Tools::checkGLErr("IPBO::IPBO", "glGenBuffers()");
+
+    std::size_t pbo_size = width * height * 4;
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo);
+    Tools::checkGLErr("IPBO::IPBO", "glBindBuffer()");
+
+    glBufferData(GL_PIXEL_PACK_BUFFER, pbo_size, 0, GL_DYNAMIC_READ);
+    Tools::checkGLErr("IPBO::IPBO", "glBufferData()");
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    Tools::checkGLErr("IPBO::IPBO", "glBindBuffer()");
+}
+
+IPBO::~IPBO() {
+    if (pbo > 0) {
+        glDeleteBuffers(1, &pbo);
+        Tools::checkGLErr("IPBO::~IPBO", "glDeleteBuffers()");
+        pbo = 0;
+    }
+}
+
+bool IPBO::isReadingAsynchronously() const {
+    return isReadingAsynchronously_;
+}
+
+void IPBO::bind() {
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo);
+    Tools::checkGLErr("IPBO::bind", "glBindBuffer()");
+}
+
+void IPBO::unbind() {
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    Tools::checkGLErr("IPBO::unbind", "glBindBuffer()");
+}
+
+void IPBO::start() {
+
+    if (!isReadingAsynchronously_) {
+        glReadBuffer(GL_COLOR_ATTACHMENT0);
+        Tools::checkGLErr("IPBO::start", "glReadBuffer()");
+
+        // Note glReadPixels last argument == 0 for PBO reads
+        glReadPixels(0, 0, width, height, OGLES_GPGPU_TEXTURE_FORMAT, GL_UNSIGNED_BYTE, 0);
+        Tools::checkGLErr("IPBO::start", "glReadPixels()");
+
+        isReadingAsynchronously_ = true;
+    }
+}
+
+void IPBO::finish(GLubyte* buffer) {
+
+    if (isReadingAsynchronously_) {
+        std::size_t pbo_size = width * height * 4;
+#if defined(OGLES_GPGPU_OSX)
+        // Note: glMapBufferRange does not seem to work in OS X
+        GLubyte* ptr = static_cast<GLubyte*>(glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY));
+#else
+        GLubyte* ptr = static_cast<GLubyte*>(glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, pbo_size, GL_MAP_READ_BIT));
+#endif
+        Tools::checkGLErr("IPBO::finish", "glMapBufferRange()");
+
+        if (ptr) {
+            memcpy(buffer, ptr, pbo_size);
+
+            glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+            Tools::checkGLErr("IPBO::finish", "glUnmapBuffer()");
+        }
+
+        isReadingAsynchronously_ = false;
+    }
+}
+
+void IPBO::read(GLubyte* buffer) {
+    start(); // Use start() and
+    finish(buffer); // finish() pair for consistent internal state
+}
+
+// ::: output/write  :::
+
+OPBO::OPBO(std::size_t width, std::size_t height)
+    : width(width)
+    , height(height) {
+
+    glGenBuffers(1, &pbo);
+    Tools::checkGLErr("OPBO::OPBO", "glGenBuffers()");
+
+    std::size_t pbo_size = width * height * 4;
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo);
+    Tools::checkGLErr("OPBO::OPBO", "glBindBuffer()");
+
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, pbo_size, 0, GL_STREAM_DRAW);
+    Tools::checkGLErr("OPBO::OPBO", "glBufferData()");
+
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    Tools::checkGLErr("OPBO::OPBO", "glBindBuffer()");
+}
+
+OPBO::~OPBO() {
+    if (pbo > 0) {
+        glDeleteBuffers(1, &pbo);
+        Tools::checkGLErr("OPBO::~OPBO", "glDeleteBuffers()");
+        pbo = 0;
+    }
+}
+
+void OPBO::bind() {
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo);
+    Tools::checkGLErr("OPBO::bind", "glBindBuffer()");
+}
+
+void OPBO::unbind() {
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    Tools::checkGLErr("OPBO::unbind", "glBindBuffer()");
+}
+
+void OPBO::write(const GLubyte* buffer, GLuint texId) {
+    std::size_t pbo_size = width * height * 4;
+
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, pbo_size, NULL, GL_STREAM_DRAW);
+    Tools::checkGLErr("OPBO::write", "glBufferData()");
+
+#if defined(OGLES_GPGPU_OSX)
+    // TODO: glMapBufferRange does not seem to work in OS X
+    GLubyte* ptr = static_cast<GLubyte*>(glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY));
+    Tools::checkGLErr("OPBO::write", "glMapBuffer()");
+#else
+    GLubyte* ptr = static_cast<GLubyte*>(glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, pbo_size, GL_MAP_WRITE_BIT));
+    Tools::checkGLErr("OPBO::write", "glMapBufferRange()");
+#endif
+
+    if (ptr) {
+        memcpy(ptr, buffer, pbo_size);
+
+        glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+        Tools::checkGLErr("OPBO::write", "glUnmapBuffer()");
+
+        glBindTexture(GL_TEXTURE_2D, texId);
+        Tools::checkGLErr("OPBO::write", "glBindTexture()");
+
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, OGLES_GPGPU_TEXTURE_FORMAT, GL_UNSIGNED_BYTE, 0);
+        Tools::checkGLErr("OPBO::write", "glTexSubImage2D()");
+    }
+}

--- a/ogles_gpgpu/common/gl/pbo.h
+++ b/ogles_gpgpu/common/gl/pbo.h
@@ -1,0 +1,109 @@
+//
+// ogles_gpgpu project - GPGPU for mobile devices and embedded systems using OpenGL ES 2.0
+//
+// See LICENSE file in project repository root for the license.
+//
+
+// Copyright (c) 2017, David Hirvonen (this file)
+
+/**
+ * Framebuffer object handler.
+ */
+#ifndef OGLES_GPGPU_COMMON_GL_PBO
+#define OGLES_GPGPU_COMMON_GL_PBO
+
+#include "../common_includes.h"
+
+namespace ogles_gpgpu {
+
+/**
+ * Input pixelbuffer object handler. Set up an OpenGL pixelbuffer for efficient
+ * pack operations (gpu->cpu).  This can be used as an alternative to
+ * glReadPixels on OpengL ES 3.0 platforms.
+ */
+
+class IPBO {
+public:
+    /**
+     * Constructor.
+     */
+    IPBO(std::size_t width, std::size_t height);
+
+    /**
+     * Destructor.
+     */
+    ~IPBO();
+
+    /**
+     * Bind the PBO (GL_PIXEL_PACK_BUFFER)
+     */
+    void bind();
+
+    /**
+     * Unbind the PBO (GL_PIXEL_PACK_BUFFER).
+     */
+    void unbind();
+
+    /**
+     * Start read operation (asynchronous/non-blocking).
+     */
+    void start(); // asynchronous
+
+    /**
+     * Pack/read pixels to <buffer> (blocking call) after a call to start().
+     */
+    void finish(GLubyte* buffer); // asynchronous
+
+    /**
+     * Perform a blocking pack from the PBO.
+     */
+    void read(GLubyte* buffer); // synchronous (start, finish)
+
+    /**
+     * Returns current processing state for asynchronous read.
+     */
+    bool isReadingAsynchronously() const;
+
+protected:
+    bool isReadingAsynchronously_ = false; // read state (async API)
+    std::size_t width; // width of PBO
+    std::size_t height; // head of PBO
+    GLuint pbo; // ID of created PBO
+};
+
+class OPBO {
+public:
+    /**
+     * Constructor.
+     */
+    OPBO(std::size_t width, std::size_t height);
+
+    /**
+     * Destructor.
+     */
+    ~OPBO();
+
+    /**
+     * Bind the PBO (GL_PIXEL_UNPACK_BUFFER)
+     */
+    void bind();
+
+    /**
+     * Unbind the PBO (GL_PIXEL_UNPACK_BUFFER)
+     */
+    void unbind();
+
+    /**
+     * Unpack/write pixels in <buffer> to texture <texId>.
+     */
+    void write(const GLubyte* buffer, GLuint texId = 0);
+
+protected:
+    std::size_t width; // width of PBO
+    std::size_t height; // head of PBO
+    GLuint pbo; // ID of created PBO
+};
+
+} // ogles_gpgpu
+
+#endif

--- a/ogles_gpgpu/common/gl/sugar.cmake
+++ b/ogles_gpgpu/common/gl/sugar.cmake
@@ -23,3 +23,11 @@ sugar_files(
     shader.cpp
     shader.h
 )
+
+if (OGLES_GPGPU_OPENGL_ES3)
+  sugar_files(
+    OGLES_GPGPU_SRCS
+    pbo.cpp
+    pbo.h
+    )
+endif()

--- a/ogles_gpgpu/common/proc/base/filterprocbase.cpp
+++ b/ogles_gpgpu/common/proc/base/filterprocbase.cpp
@@ -204,8 +204,6 @@ void FilterProcBase::filterRenderPrepare() {
     // set the viewport
     glViewport(0, 0, outFrameW, outFrameH);
 
-    glClear(GL_COLOR_BUFFER_BIT);
-
     assert(texTarget == GL_TEXTURE_2D); // texTarget = GL_TEXTURE_2D;
 
     // set input texture

--- a/ogles_gpgpu/common/proc/base/multiprocinterface.cpp
+++ b/ogles_gpgpu/common/proc/base/multiprocinterface.cpp
@@ -41,11 +41,11 @@ int MultiProcInterface::getInFrameH() const {
 bool MultiProcInterface::getWillDownscale() const {
     return getInputFilter()->getWillDownscale();
 }
-void MultiProcInterface::getResultData(unsigned char* data) const {
-    getOutputFilter()->getResultData(data);
+void MultiProcInterface::getResultData(unsigned char* data, int index) const {
+    getOutputFilter()->getResultData(data, index);
 }
-void MultiProcInterface::getResultData(FrameDelegate& delegate) const {
-    getOutputFilter()->getResultData(delegate);
+void MultiProcInterface::getResultData(const FrameDelegate& delegate, int index) const {
+    getOutputFilter()->getResultData(delegate, index);
 }
 MemTransfer* MultiProcInterface::getMemTransferObj() const {
     return getOutputFilter()->getMemTransferObj();

--- a/ogles_gpgpu/common/proc/base/multiprocinterface.h
+++ b/ogles_gpgpu/common/proc/base/multiprocinterface.h
@@ -37,8 +37,8 @@ public:
     virtual int getInFrameW() const;
     virtual int getInFrameH() const;
     virtual bool getWillDownscale() const;
-    virtual void getResultData(unsigned char* data) const;
-    virtual void getResultData(FrameDelegate& delegate) const;
+    virtual void getResultData(unsigned char* data = nullptr, int index = 0) const;
+    virtual void getResultData(const FrameDelegate& delegate = {}, int index = 0) const;
     virtual MemTransfer* getMemTransferObj() const;
     virtual MemTransfer* getInputMemTransferObj() const;
     virtual GLuint getInputTexId() const;

--- a/ogles_gpgpu/common/proc/base/procbase.cpp
+++ b/ogles_gpgpu/common/proc/base/procbase.cpp
@@ -111,20 +111,23 @@ void ProcBase::printInfo() {
         willDownscale);
 }
 
-void ProcBase::getResultData(unsigned char* data) const {
+void ProcBase::getResultData(unsigned char* data, int index) const {
     assert(fbo != NULL);
-    fbo->readBuffer(data);
+    fbo->readBuffer(data, index);
 }
 
-void ProcBase::getResultData(FrameDelegate& delegate) const {
+void ProcBase::getResultData(const FrameDelegate& delegate, int index) const {
     assert(fbo != NULL);
-    fbo->readBuffer(delegate);
+    fbo->readBuffer(delegate, index);
 }
 
 MemTransfer* ProcBase::getMemTransferObj() const {
     assert(fbo);
-
     return fbo->getMemTransfer();
+}
+
+void ProcBase::resizePBO(int count) const {
+    fbo->getMemTransfer()->resizePBO(count);
 }
 
 GLuint ProcBase::getOutputTexId() const {
@@ -224,6 +227,7 @@ void ProcBase::createFBO() {
 
     fbo = new FBO();
     fbo->setGLTexUnit(1);
+    fbo->getMemTransfer()->resizePBO(outputPboCount);
 }
 
 void ProcBase::createShader(const char* vShSrc, const char* fShSrc, GLenum target, const Shader::Attributes& attributes) {

--- a/ogles_gpgpu/common/proc/base/procbase.h
+++ b/ogles_gpgpu/common/proc/base/procbase.h
@@ -154,17 +154,23 @@ public:
     /**
      * Return the result data from the FBO.
      */
-    virtual void getResultData(unsigned char* data) const;
+    virtual void getResultData(unsigned char* data = nullptr, int index = 0) const;
 
     /**
      * Return the result data from the FBO.
      */
-    virtual void getResultData(FrameDelegate& delegate) const;
+    virtual void getResultData(const FrameDelegate& delegate = {}, int index = 0) const;
 
     /**
      * Return pointer to MemTransfer object of this processor.
      */
     virtual MemTransfer* getMemTransferObj() const;
+
+    /**
+     * Create N framebuffers for asynchronous downloads.
+     * (Only supported for >= OpenGL ES 3.0)
+     */
+    virtual void resizePBO(int count) const;
 
     /**
      * Return input texture id.
@@ -240,7 +246,7 @@ protected:
 
     bool willDownscale; // is true if output size < input size.
 
-    GLenum inputDataFmt; // input pixel data format
+    GLenum inputDataFmt = 0; // input pixel data format
 
     int inFrameW = 0; // input frame width
     int inFrameH = 0; // input frame height

--- a/ogles_gpgpu/common/proc/base/procinterface.cpp
+++ b/ogles_gpgpu/common/proc/base/procinterface.cpp
@@ -4,6 +4,10 @@ using namespace ogles_gpgpu;
 
 // ########## Filter chain
 
+void ProcInterface::setOutputPboCount(int count) {
+    outputPboCount = count;
+}
+
 void ProcInterface::setPreProcessCallback(ProcDelegate& cb) {
     m_preProcessCallback = cb;
 }

--- a/ogles_gpgpu/common/proc/base/procinterface.h
+++ b/ogles_gpgpu/common/proc/base/procinterface.h
@@ -55,6 +55,11 @@ public:
     virtual void cleanup() = 0;
 
     /**
+     * Set the output PBO count (OpenGL ES 3.0)
+     */
+    virtual void setOutputPboCount(int count);
+
+    /**
      * Set pixel data format for input data to <fmt>. Must be set before init() / reinit().
      */
     virtual void setExternalInputDataFormat(GLenum fmt) = 0;
@@ -180,17 +185,23 @@ public:
     /**
      * Return the result data from the FBO.
      */
-    virtual void getResultData(unsigned char* data) const = 0;
+    virtual void getResultData(unsigned char* data = nullptr, int index = 0) const = 0;
 
     /**
      * Return the result data from the FBO (zero copy).
      */
-    virtual void getResultData(FrameDelegate&) const = 0;
+    virtual void getResultData(const FrameDelegate& delegate = {}, int index = 0) const = 0;
 
     /**
      * Return pointer to MemTransfer object of this processor.
      */
     virtual MemTransfer* getMemTransferObj() const = 0;
+
+    /**
+     * Create N framebuffers for asynchronous downloads.
+     * (Only supported for >= OpenGL ES 3.0)
+     */
+    virtual void resizePBO(int count) const {}
 
     /**
      * Return pointer to designated input MemTransfer object of this processor.
@@ -291,6 +302,8 @@ protected:
     std::string title;
 
     bool active = true;
+
+    int outputPboCount = 1;
 
     std::vector<std::pair<ProcInterface*, int>> subscribers;
 

--- a/ogles_gpgpu/common/proc/disp.h
+++ b/ogles_gpgpu/common/proc/disp.h
@@ -45,7 +45,7 @@ public:
     virtual void setOffset(float x, float y) {
         tx = x;
         ty = y;
-    }    
+    }
 
     /**
      * Return the processors name.
@@ -75,14 +75,14 @@ public:
     /**
      * Not implemented - no output is returned because Disp renders on screen.
      */
-    virtual void getResultData(unsigned char* data) const {
+    virtual void getResultData(unsigned char* data = nullptr, int index = 0) const {
         assert(false);
     }
 
     /**
      * Not implemented - no output is returned because Disp renders on screen.
      */
-    virtual void getResultData(FrameDelegate& frameDelegate) const {
+    virtual void getResultData(const FrameDelegate& frameDelegate = {}, int index = 0) const {
         assert(false);
     }
 
@@ -95,7 +95,6 @@ public:
     }
 
 private:
-
     float tx = 0.f;
     float ty = 0.f;
     float resolutionX = 1.f;

--- a/ogles_gpgpu/common/proc/three.cpp
+++ b/ogles_gpgpu/common/proc/three.cpp
@@ -115,8 +115,6 @@ void ThreeInputProc::filterRenderPrepare() {
     // set the viewport
     glViewport(0, 0, outFrameW, outFrameH);
 
-    glClear(GL_COLOR_BUFFER_BIT);
-
     // Bind input texture 1:
     glActiveTexture(GL_TEXTURE0 + texUnit);
     glBindTexture(texTarget, texId);

--- a/ogles_gpgpu/common/proc/two.cpp
+++ b/ogles_gpgpu/common/proc/two.cpp
@@ -104,8 +104,6 @@ void TwoInputProc::filterRenderPrepare() {
     // set the viewport
     glViewport(0, 0, outFrameW, outFrameH);
 
-    glClear(GL_COLOR_BUFFER_BIT);
-
     // Bind input texture 1:
     glActiveTexture(GL_TEXTURE0 + texUnit);
     glBindTexture(texTarget, texId);

--- a/ogles_gpgpu/common/proc/yuv2rgb.h
+++ b/ogles_gpgpu/common/proc/yuv2rgb.h
@@ -23,10 +23,21 @@ namespace ogles_gpgpu {
  */
 class Yuv2RgbProc : public FilterProcBase {
 public:
+    enum ChannelKind {
+        kLA, // typically ES 2.0
+        kRG, // typically ES 3.0
+    };
+
+    enum YUVKind {
+        k601VideoRange,
+        k601FullRange,
+        k709Default
+    };
+
     /**
      * Constructor.
      */
-    Yuv2RgbProc();
+    Yuv2RgbProc(YUVKind yuvKind = k601VideoRange, ChannelKind channelKind = kLA);
 
     /**
      * Return the processors name.
@@ -59,8 +70,6 @@ private:
     static const char* vshaderYuv2RgbSrc; // fragment shader source
     static const char* fshaderYuv2RgbSrc; // fragment shader source
 
-    //GLProgram *yuvConversionProgram;
-
     GLuint luminanceTexture;
     GLuint chrominanceTexture;
 
@@ -72,6 +81,9 @@ private:
     GLint yuvConversionMatrixUniform;
 
     const GLfloat* _preferredConversion;
+
+    YUVKind yuvKind = k601VideoRange;
+    ChannelKind channelKind = kLA;
 };
 }
 

--- a/ogles_gpgpu/platform/android/gl_includes.h
+++ b/ogles_gpgpu/platform/android/gl_includes.h
@@ -11,5 +11,4 @@
  * OpenGL ES 2.0 includes for Android.
  */
 
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
+#include "../opengl/gl_includes.h"

--- a/ogles_gpgpu/platform/ios/gl_includes.h
+++ b/ogles_gpgpu/platform/ios/gl_includes.h
@@ -11,5 +11,4 @@
  * OpenGL ES 2.0 includes for iOS.
  */
 
-#include <OpenGLES/ES2/gl.h>
-#include <OpenGLES/ES2/glext.h>
+#include "../opengl/gl_includes.h"

--- a/ogles_gpgpu/platform/opengl/gl_includes.h
+++ b/ogles_gpgpu/platform/opengl/gl_includes.h
@@ -11,6 +11,9 @@
  * OpenGL (not iOS or Android) : handle all
  */
 
+#ifndef OGLES_GPGPU_OPENGL_GL_INCLUDES
+#define OGLES_GPGPU_OPENGL_GL_INCLUDES
+
 // clang-format off
 
 //define something for Windows (64-bit)
@@ -19,27 +22,48 @@
 #  include <windows.h> // CMakeLists.txt defines NOMINMAX
 #  include <gl/glew.h>
 #  include <GL/gl.h>
-#  include <GL/glu.h>
 #elif __APPLE__
 #  include "TargetConditionals.h"
 #  if (TARGET_OS_IPHONE && TARGET_IPHONE_SIMULATOR) || TARGET_OS_IPHONE
-#    include <OpenGLES/ES2/gl.h>
-#    include <OpenGLES/ES2/glext.h>
+#    if defined(OGLES_GPGPU_OPENGL_ES3)
+#      include <OpenGLES/ES3/gl.h>
+#      include <OpenGLES/ES3/glext.h>
+#    else
+#      include <OpenGLES/ES2/gl.h>
+#      include <OpenGLES/ES2/glext.h>
+#    endif
 #  else
-#    include <OpenGL/gl.h>
-#    include <OpenGL/glu.h>
-#    include <OpenGL/glext.h>
+#    if defined(OGLES_GPGPU_OPENGL_ES3)
+#      include <OpenGL/gl3.h>
+#      include <OpenGL/gl3ext.h>
+#    else
+#      include <OpenGL/gl.h>
+#      include <OpenGL/glext.h>
+#    endif
 #  endif
 #elif defined(__ANDROID__) || defined(ANDROID)
-#  include <GLES2/gl2.h>
-#  include <GLES2/gl2ext.h>
+#  if defined(OGLES_GPGPU_OPENGL_ES3)
+#    include <GLES3/gl3.h>
+#    include <GLES3/gl3ext.h>
+#  else
+#    include <GLES2/gl2.h>
+#    include <GLES2/gl2ext.h>
+#  endif
 #elif defined(__linux__) || defined(__unix__) || defined(__posix__)
 #  define GL_GLEXT_PROTOTYPES 1
 #  include <GL/gl.h>
-#  include <GL/glu.h>
 #  include <GL/glext.h>
 #else
 #  error platform not supported.
 #endif
-
 // clang-format on
+
+// clang-format off
+#ifdef ANDROID
+#  define OGLES_GPGPU_TEXTURE_FORMAT GL_RGBA
+#else
+#  define OGLES_GPGPU_TEXTURE_FORMAT GL_BGRA
+#endif
+// clang-format off
+
+#endif // OGLES_GPGPU_OPENGL_GL_INCLUDES

--- a/ogles_gpgpu/platform/sugar.cmake
+++ b/ogles_gpgpu/platform/sugar.cmake
@@ -11,15 +11,27 @@ endif()
 
 include(sugar_include)
 
-if(IOS)
-  sugar_include(ios)
-elseif(APPLE)
-  sugar_include(osx)
-elseif(ANDROID)
-  sugar_include(android)
+if(ANDROID OR IOS)
+  set(ogles_gpgpu_is_mobile TRUE)
 else()
-  message("include opengl platforms.............")
+  set(ogles_gpgpu_is_mobile FALSE)
+endif()
+
+# We will use the vanilla OpenGL implementation in case
+# of standard OpenGL platforms (i.e., not OpenGL ES) or
+# in cases where >= OpenGL ES 3.0 is available.  On those
+# platforms we can use PBO for efficient GPU->CPU reads.
+# If we are using OpenGL ES 2.0 on mobile devices then
+# we will use platform specific extensions to facilitate
+# efficient DMA reads of OpenGL textures.
+if(OGLES_GPGPU_OPENGL_ES3 OR NOT ${ogles_gpgpu_is_mobile})
   sugar_include(opengl)
+else()
+  if(IOS)
+    sugar_include(ios)
+  elseif(ANDROID)
+    sugar_include(android )
+  endif()
 endif()
 
 

--- a/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
+++ b/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
@@ -1,5 +1,9 @@
-#include <aglet/aglet.h>
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
 #include <aglet/GLContext.h>
+#include <aglet/aglet.h>
 
 #include <gtest/gtest.h>
 
@@ -14,6 +18,8 @@
 #  define TEXTURE_FORMAT GL_BGRA
 #endif
 // clang-format off
+
+#define OGLES_GPGPU_DEBUG_YUV 1
 
 #include "../common/gl/memtransfer_optimized.h"
 
@@ -49,16 +55,13 @@
 #include "../common/proc/flow.h"         // [0]
 #include "../common/proc/rgb2hsv.h"      // [0]
 #include "../common/proc/hsv2rgb.h"      // [0]
-#include "../common/proc/remap.h"        // [ ] (needs work)
+#include "../common/proc/remap.h"        // [ ]
 // clang-format on
 
 // virtual (tested indirectly)
 //#include "../common/proc/filter3x3.h"
 //#include "../common/proc/two.h"
 //#include "../common/proc/three.h"
-
-// NA:
-//#include "../common/proc/disp.h"
 
 int gauze_main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
@@ -67,20 +70,30 @@ int gauze_main(int argc, char** argv) {
 }
 
 struct GLTexture {
-    GLTexture(std::size_t width, std::size_t height, GLenum texType, void* data) {
+    GLTexture(std::size_t width, std::size_t height, GLenum texType, void* data, GLint texFormat = GL_RGBA) {
         glGenTextures(1, &texId);
+        assert(glGetError() == GL_NO_ERROR);
+
         glBindTexture(GL_TEXTURE_2D, texId);
+        assert(glGetError() == GL_NO_ERROR);
+
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        assert(glGetError() == GL_NO_ERROR);
+
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, texType, GL_UNSIGNED_BYTE, data);
+        glTexImage2D(GL_TEXTURE_2D, 0, texFormat, width, height, 0, texType, GL_UNSIGNED_BYTE, data);
+        assert(glGetError() == GL_NO_ERROR);
+
         glBindTexture(GL_TEXTURE_2D, 0);
+        assert(glGetError() == GL_NO_ERROR);
     }
 
     ~GLTexture() {
         glDeleteTextures(1, &texId);
+        assert(glGetError() == GL_NO_ERROR);
     }
 
     operator GLuint() const {
@@ -103,7 +116,7 @@ static cv::Mat getImage(ogles_gpgpu::ProcInterface& proc, cv::Mat& frame) {
     return frame;
 }
 
-static cv::Mat getTestImage(int width, int height, int stripe, bool alpha) {
+static cv::Mat getTestImage(int width, int height, int stripe, bool alpha, GLenum format) {
     // Create a test image:
     cv::Mat test(height, width, CV_8UC3, cv::Scalar::all(0));
     cv::Point center(test.cols / 2, test.rows / 2);
@@ -111,9 +124,14 @@ static cv::Mat getTestImage(int width, int height, int stripe, bool alpha) {
         cv::circle(test, center, i, cv::Scalar(rand() % 255, rand() % 255, rand() % 255), -1, 8);
     }
 
+    if (format == GL_RGBA /* or GL_RGB */) {
+        cv::cvtColor(test, test, cv::COLOR_BGR2RGB);
+    }
+
     if (alpha) {
         cv::cvtColor(test, test, cv::COLOR_BGR2BGRA); // add alpha
     }
+
     return test;
 }
 
@@ -121,112 +139,240 @@ static cv::Mat getTestImage(int width, int height, int stripe, bool alpha) {
 //### Shader Testing ###
 //######################
 
+#include <chrono>
+
 static int gWidth = 640;
 static int gHeight = 480;
+static aglet::GLContext::GLVersion gVersion = aglet::GLContext::kGLES30;
 
-#if !defined(_WIN32) && !defined(_WIN64)
-// vs-14-2015 GLSL reports the following error due to internal preprocessor #define
-// > could not compile shader program.  error log:
-// > 0:1(380): preprocessor error: syntax error, unexpected HASH_TOKEN
-TEST(OGLESGPGPUTest, MedianProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
-    ASSERT_TRUE(context && (*context));
-    if(context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 20, true);
-
-        glActiveTexture(GL_TEXTURE0);
-        ogles_gpgpu::VideoSource video;
-        ogles_gpgpu::MedianProc median;
-
-        video.set(&median);
-
-        cv::Mat noise = cv::Mat::zeros(test.rows, test.cols, CV_8UC1);
-        cv::randu(noise, 0, 255);
-        test.setTo(0, noise < 30);
-        test.setTo(255, noise > 225);
-
-        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
-
-        cv::Mat result;
-        getImage(median, result);
-        ASSERT_FALSE(result.empty());
-    }
-}
-#endif
-
-#if !defined(ANDROID)
-// glTexImage2D w/ GL_LUMINANCE or GL_LUMINANCE_ALPHA report error 1282 in tests w/ android-ndk-r10e-api-19
-// TODO: The GL_RED_EXT seems to be available in >= android-21
-TEST(OGLESGPGPUTest, Yuv2RgbProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();    
+#if defined(OGLES_GPGPU_OPENGL_ES3)
+TEST(OGLESGPGPUTest, PingPong) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
     ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        static const int width = 640, height = 480;
+        static const int value = 1, g = 10, width = 2048, height = 2048;
+        cv::Mat test(height, width, CV_8UC4, cv::Scalar(value, value, value, 255));
+
+        glActiveTexture(GL_TEXTURE0);
+
+        ogles_gpgpu::GainProc gain(g);
+        gain.setOutputPboCount(2); // support ping-pong
+
+        ogles_gpgpu::VideoSource video;
+        video.set(&gain);
+
+        cv::Mat tmp(height, width, CV_8UC4, cv::Scalar::all(0));
+        for (int i = 0; i < 4; i++) {
+            video({ { test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT });
+
+            gain.getResultData(nullptr, (i + 0) % 2); // queue up transfer for current frame:
+            if (i > 0) {
+                gain.getResultData(tmp.ptr<uint8_t>(), (i - 1) % 2);
+                ASSERT_EQ(static_cast<int>(cv::mean(tmp)[0]), (value * g));
+            }
+        }
+
+        cv::Mat result;
+        getImage(gain, result);
+        ASSERT_EQ(static_cast<int>(cv::mean(result)[0]), (value * g));
+    }
+}
+#endif // defined(OGLES_GPGPU_OPENGL_ES3)
+
+TEST(OGLESGPGPUTest, GrayScaleProc) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
+    ASSERT_TRUE(context && (*context));
+    if (context && *context) {
+        cv::Mat test = getTestImage(gWidth, gHeight, 10, true, TEXTURE_FORMAT);
+        glActiveTexture(GL_TEXTURE0);
+        ogles_gpgpu::VideoSource video;
+        ogles_gpgpu::GrayscaleProc gray;
+
+        gray.setGrayscaleConvType(ogles_gpgpu::GRAYSCALE_INPUT_CONVERSION_RGB);
+
+        video.set(&gray);
+
+        for (int i = 0; i < 1000; i++) {
+            video({ { test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT });
+        }
+
+        cv::Mat result;
+        getImage(gray, result);
+        ASSERT_FALSE(result.empty());
+
+        cv::Mat truth;
+        cv::cvtColor(test, truth, (TEXTURE_FORMAT == GL_RGBA) ? cv::COLOR_RGBA2GRAY : cv::COLOR_BGRA2GRAY);
+
+        std::cout << cv::mean(truth) << " vs " << cv::mean(result) << std::endl;
+
+        // clang-off
+        auto almost_equal = [](const cv::Vec4b& a, const cv::Vec4b& b) {
+            int delta = std::abs(static_cast<int>(a[0]) - static_cast<int>(b[0]));
+            if (delta > 2) {
+                //std::cout << "delta: " << delta << std::endl;
+                return false;
+            }
+            return true;
+        };
+        ASSERT_TRUE(std::equal(truth.begin<cv::Vec4b>(), truth.end<cv::Vec4b>(), result.begin<cv::Vec4b>(), almost_equal));
+        // clang-on
+    }
+}
+
+TEST(OGLESGPGPUTest, WriteAndRead) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
+    ASSERT_TRUE(context && (*context));
+    if (context && *context) {
+        cv::Mat test = getTestImage(gWidth, gHeight, 10, true, TEXTURE_FORMAT);
+        glActiveTexture(GL_TEXTURE0);
+
+        ogles_gpgpu::GainProc gain;
+        auto* filter = dynamic_cast<ogles_gpgpu::ProcInterface*>(&gain);
+
+        static const bool prepareForExternalInput = true;
+
+        // Set pixel data format for input data to <fmt>. Must be set before init() / reinit().
+        filter->setExternalInputDataFormat(TEXTURE_FORMAT);
+
+        // Init the processor for input frames of size <inW>x<inH> which is at position <order>
+        // in the processing pipeline.
+        filter->init(test.cols, test.rows, 0, prepareForExternalInput);
+
+        // Insert external data into this processor. It will be used as input texture.
+        // Note: init() must have been called with prepareForExternalInput = true for that.
+        filter->setExternalInputData(test.ptr<std::uint8_t>());
+
+        // Createa and bind an output FBO + texture.
+        filter->createFBOTex(false);
+
+        // Notify the MemTransfer object that we are using raw data, as opposed to
+        // platform specific image types (i.e., CMSampleBuffer)
+        filter->getInputMemTransferObj()->setUseRawPixels(true);
+
+        // Perform off screen rendering to output FBO:
+        gain.render();
+
+        cv::Mat result;
+        getImage(gain, result);
+
+        auto almost_equal = [](const cv::Vec4b& a, const cv::Vec4b& b) {
+            int delta = std::abs(static_cast<int>(a[0]) - static_cast<int>(b[0]));
+            if (delta > 2) {
+                return false;
+            }
+            return true;
+        };
+
+        ASSERT_TRUE(std::equal(test.begin<cv::Vec4b>(), test.end<cv::Vec4b>(), result.begin<cv::Vec4b>(), almost_equal));
+    }
+}
+
+TEST(OGLESGPGPUTest, Yuv2RgbProc) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
+    ASSERT_TRUE(context && (*context));
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
+    if (context && *context) {
 
         cv::Mat green(1, 1, CV_8UC3, cv::Scalar(0, 255, 0)), yuv;
         cv::cvtColor(green, yuv, cv::COLOR_BGR2YUV);
         cv::Vec3b& value = yuv.at<cv::Vec3b>(0, 0);
 
         // Create constant color buffers:
-        std::vector<std::uint8_t> y(width * height, value[0]), uv(width * height / 2);
+        std::vector<std::uint8_t> y(gWidth * gHeight, value[0]), uv(gWidth * gHeight / 2);
         for (int i = 0; i < uv.size(); i += 2) {
             uv[i + 0] = value[1];
             uv[i + 1] = value[2];
         }
 
+#if defined(OGLES_GPGPU_OPENGL_ES3)
         // Luminance texture:
-        GLTexture luminanceTexture(gWidth, gHeight, GL_LUMINANCE, y.data());
+        GLTexture luminanceTexture(gWidth, gHeight, GL_RED, y.data(), GL_R8);
         ASSERT_EQ(glGetError(), GL_NO_ERROR);
+        std::cout << "ES3 k601VideoRange kRG" << std::endl;
 
         // Chrominance texture (interleaved):
-        GLTexture chrominanceTexture(width / 2, height / 2, GL_LUMINANCE_ALPHA, uv.data());
+        GLTexture chrominanceTexture(gWidth / 2, gHeight / 2, GL_RG, uv.data(), GL_RG8);
         ASSERT_EQ(glGetError(), GL_NO_ERROR);
 
-        ogles_gpgpu::Yuv2RgbProc yuv2rgb;
-        yuv2rgb.init(gWidth, gHeight, 0, true);
+        ogles_gpgpu::Yuv2RgbProc yuv2rgb(ogles_gpgpu::Yuv2RgbProc::k601VideoRange, ogles_gpgpu::Yuv2RgbProc::kRG);
+#else
+        // Luminance texture:
+        GLTexture luminanceTexture(gWidth, gHeight, GL_LUMINANCE, y.data(), GL_LUMINANCE);
+        ASSERT_EQ(glGetError(), GL_NO_ERROR);
+        std::cout << "ES2 k601VideoRange kLA" << std::endl;
+
+        // Chrominance texture (interleaved):
+        GLTexture chrominanceTexture(gWidth / 2, gHeight / 2, GL_LUMINANCE_ALPHA, uv.data(), GL_LUMINANCE_ALPHA);
+        ASSERT_EQ(glGetError(), GL_NO_ERROR);
+
+        ogles_gpgpu::Yuv2RgbProc yuv2rgb(ogles_gpgpu::Yuv2RgbProc::k601VideoRange, ogles_gpgpu::Yuv2RgbProc::kLA);
+#endif
+
+        // Set pixel data format for input data to <fmt>. Must be set before init() / reinit().
         yuv2rgb.setExternalInputDataFormat(0); // for yuv
+
+        // Init the processor for input frames of size <inW>x<inH> which is at position <order>
+        // in the processing pipeline.
+        yuv2rgb.init(gWidth, gHeight, 0, true);
+
+        // Be sure to specify stanrdard (GL_RGBA) output texture type
+        // for this case where input textures == 0 are handled as special
+        // separate Y and UV textures.
         yuv2rgb.getMemTransferObj()->setOutputPixelFormat(TEXTURE_FORMAT);
+
+        // Create an FBO
         yuv2rgb.createFBOTex(false);
+
+        // Provide the input Y and UV textures:
         yuv2rgb.setTextures(luminanceTexture, chrominanceTexture);
+
+        // Perform the rendering
         yuv2rgb.render();
 
         cv::Mat result;
         getImage(yuv2rgb, result);
         ASSERT_FALSE(result.empty());
 
-        //auto mu = cv::mean(result);
-        //ASSERT_EQ(mu[0], 0);
-        //ASSERT_EQ(mu[1], 255);
-        //ASSERT_EQ(mu[2], 0);
-    }
-}
-#endif
+        auto mu = cv::mean(result);
 
-TEST(OGLESGPGPUTest, GrayScaleProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
-    ASSERT_TRUE(context && (*context));
-    if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 10, true);
-        glActiveTexture(GL_TEXTURE0);
-        ogles_gpgpu::VideoSource video;
-        ogles_gpgpu::GrayscaleProc gray;
+#if OGLES_GPGPU_DEBUG_YUV
+        ogles_gpgpu::GainProc yProc;
+        yProc.prepare(gWidth, gHeight);
+        yProc.process(luminanceTexture, 1, GL_TEXTURE_2D);
+        cv::Mat yProcOut;
+        getImage(yProc, yProcOut);
 
-        video.set(&gray);
-        video({ { test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT });
+        ogles_gpgpu::GainProc uvProc;
+        uvProc.prepare(gWidth, gHeight);
+        uvProc.process(chrominanceTexture, 1, GL_TEXTURE_2D);
+        cv::Mat uvProcOut;
+        getImage(uvProc, uvProcOut);
 
-        cv::Mat result;
-        getImage(gray, result);
-        ASSERT_FALSE(result.empty());
+        std::cout << "yuv_in  : " << value << std::endl;
+        std::cout << "rgb_out : " << mu << std::endl;
+        std::cout << "y_      : " << cv::mean(yProcOut) << std::endl;
+        std::cout << "uv_     : " << cv::mean(uvProcOut) << std::endl;
+        std::cout << "Format: " << int(yProc.getMemTransferObj()->getOutputPixelFormat()) << std::endl;
+#endif // OGLES_GPGPU_DEBUG_YUV
+
+        ASSERT_LE(mu[0], 8);
+        ASSERT_GE(mu[1], 250);
+        ASSERT_LE(mu[2], 8);
     }
 }
 
 TEST(OGLESGPGPUTest, AdaptThreshProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 10, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 10, true, TEXTURE_FORMAT);
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
         ogles_gpgpu::AdaptThreshProc thresh;
@@ -241,12 +387,13 @@ TEST(OGLESGPGPUTest, AdaptThreshProc) {
 }
 
 TEST(OGLESGPGPUTest, GainProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
         static const int value = 1, g = 10;
-        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value, value, value, 255));
+        cv::Mat test(gWidth, gHeight, CV_8UC4, cv::Scalar(value, value, value, 255));
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -262,14 +409,15 @@ TEST(OGLESGPGPUTest, GainProc) {
 }
 
 TEST(OGLESGPGPUTest, BlendProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
         const float alpha = 0.5f;
         const int value = 2;
         const int a = 1, b = 10;
-        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value, value, value, 255));
+        cv::Mat test(gWidth, gHeight, CV_8UC4, cv::Scalar(value, value, value, 255));
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -290,9 +438,10 @@ TEST(OGLESGPGPUTest, BlendProc) {
 }
 
 TEST(OGLESGPGPUTest, FIFOProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -300,7 +449,7 @@ TEST(OGLESGPGPUTest, FIFOProc) {
         video.set(&fifo);
 
         for (int i = 0; i < 3; i++) {
-            cv::Mat test(640, 480, CV_8UC4, cv::Scalar(i, i, i, 255));
+            cv::Mat test(gWidth, gHeight, CV_8UC4, cv::Scalar(i, i, i, 255));
             video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
         }
 
@@ -313,9 +462,10 @@ TEST(OGLESGPGPUTest, FIFOProc) {
 }
 
 TEST(OGLESGPGPUTest, TransformProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -336,7 +486,7 @@ TEST(OGLESGPGPUTest, TransformProc) {
 
         transform.setTransformMatrix(matrix);
 
-        cv::Mat test = getTestImage(640, 480, 10, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 10, true, TEXTURE_FORMAT);
         video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
 
         cv::Mat result;
@@ -346,13 +496,14 @@ TEST(OGLESGPGPUTest, TransformProc) {
 }
 
 TEST(OGLESGPGPUTest, DiffProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
         const int value = 2;
         const int a = 1, b = 10;
-        cv::Mat test(640, 480, CV_8UC4, cv::Scalar(value, value, value, 255));
+        cv::Mat test(gWidth, gHeight, CV_8UC4, cv::Scalar(value, value, value, 255));
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -373,11 +524,12 @@ TEST(OGLESGPGPUTest, DiffProc) {
 }
 
 TEST(OGLESGPGPUTest, GaussianProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 1, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 1, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -394,11 +546,12 @@ TEST(OGLESGPGPUTest, GaussianProc) {
 }
 
 TEST(OGLESGPGPUTest, GaussianOptProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 1, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 1, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -414,11 +567,12 @@ TEST(OGLESGPGPUTest, GaussianOptProc) {
 }
 
 TEST(OGLESGPGPUTest, BoxOptProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 1, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 1, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -434,9 +588,10 @@ TEST(OGLESGPGPUTest, BoxOptProc) {
 }
 
 TEST(OGLESGPGPUTest, HessianProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
         cv::Mat test(gWidth, gHeight, CV_8UC1, cv::Scalar::all(0));
 
@@ -465,11 +620,12 @@ TEST(OGLESGPGPUTest, HessianProc) {
 }
 
 TEST(OGLESGPGPUTest, LbpProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 1, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 1, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -485,11 +641,12 @@ TEST(OGLESGPGPUTest, LbpProc) {
 }
 
 TEST(OGLESGPGPUTest, Fir3Proc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        const cv::Size size(640, 480);
+        const cv::Size size(gWidth, gHeight);
         const cv::Point center(size.width / 2, size.height / 2);
         const float radius = size.height / 2;
 
@@ -530,11 +687,12 @@ TEST(OGLESGPGPUTest, Fir3Proc) {
 }
 
 TEST(OGLESGPGPUTest, GradProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -550,9 +708,10 @@ TEST(OGLESGPGPUTest, GradProc) {
 }
 
 TEST(OGLESGPGPUTest, LowPassProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
         std::vector<cv::Mat> images{
             cv::Mat(gWidth, gHeight, CV_8UC4, cv::Scalar(0, 0, 0, 255)),
@@ -576,9 +735,10 @@ TEST(OGLESGPGPUTest, LowPassProc) {
 }
 
 TEST(OGLESGPGPUTest, HighPassProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
         std::vector<cv::Mat> images{
             cv::Mat(gWidth, gHeight, CV_8UC4, cv::Scalar(0, 0, 0, 255)),
@@ -602,11 +762,12 @@ TEST(OGLESGPGPUTest, HighPassProc) {
 }
 
 TEST(OGLESGPGPUTest, ThreshProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -622,11 +783,12 @@ TEST(OGLESGPGPUTest, ThreshProc) {
 }
 
 TEST(OGLESGPGPUTest, PyramidProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -642,9 +804,10 @@ TEST(OGLESGPGPUTest, PyramidProc) {
 }
 
 TEST(OGLESGPGPUTest, IxytProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -659,7 +822,7 @@ TEST(OGLESGPGPUTest, IxytProc) {
         fifo.addWithDelay(&ixyt, 0, 0);
 
         for (int i = 0; i < 5; i++) {
-            cv::Mat test = getTestImage(640, 480, 2, true);
+            cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
             video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
         }
 
@@ -674,11 +837,12 @@ TEST(OGLESGPGPUTest, IxytProc) {
 }
 
 TEST(OGLESGPGPUTest, TensorProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -694,11 +858,12 @@ TEST(OGLESGPGPUTest, TensorProc) {
 }
 
 TEST(OGLESGPGPUTest, ShiTomasiProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
         for (int i = 0; i < 100; i++) {
             cv::Point p0(rand() % test.cols, rand() % test.rows);
             cv::Point p1(rand() % test.cols, rand() % test.rows);
@@ -727,11 +892,12 @@ TEST(OGLESGPGPUTest, ShiTomasiProc) {
 }
 
 TEST(OGLESGPGPUTest, HarrisProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(640, 480, 2, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 2, true, TEXTURE_FORMAT);
         for (int i = 0; i < 100; i++) {
             cv::Point p0(rand() % test.cols, rand() % test.rows);
             cv::Point p1(rand() % test.cols, rand() % test.rows);
@@ -760,9 +926,10 @@ TEST(OGLESGPGPUTest, HarrisProc) {
 }
 
 TEST(OGLESGPGPUTest, NmsProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
         cv::Mat test(gWidth, gHeight, CV_8UC1, cv::Scalar::all(0));
 
@@ -793,11 +960,12 @@ TEST(OGLESGPGPUTest, NmsProc) {
 }
 
 TEST(OGLESGPGPUTest, FlowProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -821,11 +989,12 @@ TEST(OGLESGPGPUTest, FlowProc) {
 }
 
 TEST(OGLESGPGPUTest, Rgb2HsvProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -841,11 +1010,12 @@ TEST(OGLESGPGPUTest, Rgb2HsvProc) {
 }
 
 TEST(OGLESGPGPUTest, Hsv2RgbProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -861,11 +1031,12 @@ TEST(OGLESGPGPUTest, Hsv2RgbProc) {
 }
 
 TEST(OGLESGPGPUTest, LNormProc) {
-    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight); (*context)();
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
     ASSERT_TRUE(context && (*context));
-    ASSERT_EQ(glGetError(), GL_NO_ERROR);    
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
     if (context && *context) {
-        cv::Mat test = getTestImage(gWidth, gHeight, 3, true);
+        cv::Mat test = getTestImage(gWidth, gHeight, 3, true, TEXTURE_FORMAT);
 
         glActiveTexture(GL_TEXTURE0);
         ogles_gpgpu::VideoSource video;
@@ -881,3 +1052,34 @@ TEST(OGLESGPGPUTest, LNormProc) {
         ASSERT_FALSE(result.empty());
     }
 }
+
+#if !defined(_WIN32) && !defined(_WIN64)
+// vs-14-2015 GLSL reports the following error due to internal preprocessor #define
+// > could not compile shader program.  error log:
+// > 0:1(380): preprocessor error: syntax error, unexpected HASH_TOKEN
+TEST(OGLESGPGPUTest, MedianProc) {
+    auto context = aglet::GLContext::create(aglet::GLContext::kAuto, {}, gWidth, gHeight, gVersion);
+    (*context)();
+    ASSERT_TRUE(context && (*context));
+    if (context && *context) {
+        cv::Mat test = getTestImage(gWidth, gHeight, 20, true, TEXTURE_FORMAT);
+
+        glActiveTexture(GL_TEXTURE0);
+        ogles_gpgpu::VideoSource video;
+        ogles_gpgpu::MedianProc median;
+
+        video.set(&median);
+
+        cv::Mat noise = cv::Mat::zeros(test.rows, test.cols, CV_8UC1);
+        cv::randu(noise, 0, 255);
+        test.setTo(0, noise < 30);
+        test.setTo(255, noise > 225);
+
+        video({ test.cols, test.rows }, test.ptr<void>(), true, 0, TEXTURE_FORMAT);
+
+        cv::Mat result;
+        getImage(median, result);
+        ASSERT_FALSE(result.empty());
+    }
+}
+#endif


### PR DESCRIPTION
* Pixelbuffer object support (ES 3.0) w/  {I,O}PBO classes
* add ping-pong pbo read test
* add async/double buffer api modes for PBO reads `getResultData(…, int index=0)`
* use const delegate for getResultData() to support “null” delegate; change variable name
* use aglet hunter package
* bump hunter version v0.19.36
* bump ogles_gpgpu version
* add hunter related notes to CMakeLists.txt
* update Yuv2RgbProc unit test and shaders (add control for coefficients)
* add WriteAndRead unit test (exercise ES 3.0 PBO input and    * include master gl_includes.h for all-in-one gl platform definitions
* remove glu includes
* remove glClear (texture is unbound) in filterRenderPrepare()
* add FindOpengLES3.cmake for android
* add additional test conditions to shader tests (grayscale, etc)