### PR TITLE
v0.2.9 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,16 +129,6 @@ script:
     --jobs 2
     ${INSTALL} ${TEST}
 
-  # Upload to server
-  - git clone https://github.com/ruslo/hunter
-  - >
-    ./hunter/maintenance/upload-cache-to-github.py
-    --username ingenue
-    --repo-owner ingenue
-    --repo hunter-cache
-    --cache-dir ${HOME}/.hunter/_Base/Cache
-    --temp-dir ${HOME}/__TEMP_HUNTER
-
 branches:
   except:
     - /^pr\..*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,16 +3,22 @@
 
 cmake_minimum_required(VERSION 3.0)
 
+include("cmake/hunter_cache_update.cmake")
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-  URL "https://github.com/ruslo/hunter/archive/v0.19.234.tar.gz"
-  SHA1 "3deec1041bd01c91e78269522b901fbab3a765e5"
+  URL "https://github.com/ruslo/hunter/archive/v0.20.14.tar.gz"
+  SHA1 "18cdbf5c47abdda437c73bf5437b7c3c65afe47c"
   LOCAL    
 )
 
 project(ogles_gpgpu VERSION 0.2.8)
+
+# hunter_add_package(check_ci_tag)
+# find_package(check_ci_tag CONFIG REQUIRED)
+# check_ci_tag()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,11 @@ HunterGate(
   LOCAL    
 )
 
-project(ogles_gpgpu VERSION 0.2.8)
+project(ogles_gpgpu VERSION 0.2.9)
 
-# hunter_add_package(check_ci_tag)
-# find_package(check_ci_tag CONFIG REQUIRED)
-# check_ci_tag()
+hunter_add_package(check_ci_tag)
+find_package(check_ci_tag CONFIG REQUIRED)
+check_ci_tag()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,10 +58,6 @@ install:
 build_script:
   - cmd: python %POLLY_SOURCE_DIR%\bin\polly.py --toolchain "%TOOLCHAIN%" --config "%CONFIG%" --verbose --fwd OGLES_GPGPU_BUILD_TESTS=ON
 
-  # Upload to server
-  - cmd: git clone https://github.com/ruslo/hunter
-  - cmd: python %cd%\hunter\maintenance\upload-cache-to-github.py --username ingenue --repo-owner ingenue --repo hunter-cache --cache-dir C:/.hunter/_Base/Cache --temp-dir C:/.hunter/__TEMP_HUNTER
-
 branches:
   except:
     - /^pr\..*/

--- a/cmake/Hunter/passwords.cmake
+++ b/cmake/Hunter/passwords.cmake
@@ -1,0 +1,11 @@
+hunter_upload_password(
+    # REPO_OWNER + REPO = https://github.com/ingenue/hunter-cache
+    REPO_OWNER "ingenue"
+    REPO "hunter-cache"
+
+    # USERNAME = https://github.com/ingenue
+    USERNAME "ingenue"
+
+    # PASSWORD = GitHub token saved as a secure environment variable
+    PASSWORD "$ENV{GITHUB_USER_PASSWORD}"
+)

--- a/cmake/hunter_cache_update.cmake
+++ b/cmake/hunter_cache_update.cmake
@@ -22,7 +22,7 @@ endif()
 
 set(
     HUNTER_PASSWORDS_PATH
-    "${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/passwords.cmake"
+    "${CMAKE_CURRENT_LIST_DIR}/Hunter/passwords.cmake"
     CACHE
     FILEPATH
     "Hunter passwords"

--- a/cmake/hunter_cache_update.cmake
+++ b/cmake/hunter_cache_update.cmake
@@ -1,0 +1,29 @@
+# https://github.com/forexample/hunter-cache-use/blob/master/CMakeLists.txt
+
+set(
+    HUNTER_CACHE_SERVERS
+    "https://github.com/ingenue/hunter-cache"
+    CACHE
+    STRING
+    "Default cache server"
+)
+
+# https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+string(COMPARE EQUAL "$ENV{TRAVIS}" "true" is_travis)
+
+# https://www.appveyor.com/docs/environment-variables/
+string(COMPARE EQUAL "$ENV{APPVEYOR}" "True" is_appveyor)
+
+string(COMPARE EQUAL "$ENV{GITHUB_USER_PASSWORD}" "" password_is_empty)
+
+if((is_travis OR is_appveyor) AND NOT password_is_empty)
+  option(HUNTER_RUN_UPLOAD "Upload cache binaries" ON)
+endif()
+
+set(
+    HUNTER_PASSWORDS_PATH
+    "${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/passwords.cmake"
+    CACHE
+    FILEPATH
+    "Hunter passwords"
+)

--- a/ogles_gpgpu/common/gl/fbo.cpp
+++ b/ogles_gpgpu/common/gl/fbo.cpp
@@ -35,11 +35,6 @@ FBO::FBO(bool doAlloc) {
 
 FBO::~FBO() {
     destroyFramebuffer();
-
-    // attached texture will be destroyed together with memTransfer instance
-    if (memTransfer) {
-        delete memTransfer;
-    }
 }
 
 void FBO::bind() {

--- a/ogles_gpgpu/common/gl/fbo.h
+++ b/ogles_gpgpu/common/gl/fbo.h
@@ -17,6 +17,8 @@
 #include "../core.h"
 #include "memtransfer_factory.h"
 
+#include <memory>
+
 namespace ogles_gpgpu {
 
 class Core;
@@ -134,7 +136,7 @@ public:
      * Get MemTransfer object associated with this FBO.
      */
     MemTransfer* getMemTransfer() const {
-        return memTransfer;
+        return memTransfer.get();
     }
 
 protected:
@@ -145,7 +147,7 @@ protected:
 
     Core* core; // Core singleton
 
-    MemTransfer* memTransfer = nullptr; // MemTransfer object associated with this FBO
+    std::unique_ptr<MemTransfer> memTransfer; // MemTransfer object associated with this FBO
 
     GLuint id; // OpenGL FBO id
     GLuint glTexUnit; // GL texture unit (to be used in glActiveTexture()) for output texture

--- a/ogles_gpgpu/common/gl/memtransfer.cpp
+++ b/ogles_gpgpu/common/gl/memtransfer.cpp
@@ -102,7 +102,7 @@ GLuint MemTransfer::prepareInput(int inTexW, int inTexH, GLenum inputPxFormat, v
 
 #if defined(OGLES_GPGPU_OPENGL_ES3)
     // ::::::: allocate ::::::::::
-    pboWrite = new OPBO(inputW, inputH);
+    pboWrite = std::unique_ptr<OPBO>(new OPBO(inputW, inputH));
 #endif // defined(OGLES_GPGPU_OPENGL_ES3)
 
     // done
@@ -171,8 +171,7 @@ void MemTransfer::releaseInput() {
 
 #if defined(OGLES_GPGPU_OPENGL_ES3)
     if (pboWrite) {
-        delete pboWrite;
-        pboWrite = nullptr;
+        pboWrite.reset();
     }
 #endif // defined(OGLES_GPGPU_OPENGL_ES3)
 }

--- a/ogles_gpgpu/common/gl/memtransfer.h
+++ b/ogles_gpgpu/common/gl/memtransfer.h
@@ -232,7 +232,7 @@ protected:
 #endif // OGLES_GPGPU_USE_CLASS_READ
 
 #if OGLES_GPGPU_USE_CLASS_WRITE
-    OPBO* pboWrite = nullptr;
+    std::unique_ptr<OPBO> pboWrite;
 #else // OGLES_GPGPU_USE_CLASS_WRITE
     GLuint pboWrite;
 #endif // OGLES_GPGPU_USE_CLASS_WRITE

--- a/ogles_gpgpu/common/gl/memtransfer_factory.cpp
+++ b/ogles_gpgpu/common/gl/memtransfer_factory.cpp
@@ -24,21 +24,21 @@ using namespace ogles_gpgpu;
 
 bool MemTransferFactory::usePlatformOptimizations = false;
 
-MemTransfer* MemTransferFactory::createInstance() {
-    MemTransfer* instance = NULL;
+std::unique_ptr<MemTransfer> MemTransferFactory::createInstance() {
+    std::unique_ptr<MemTransfer> instance;
 
     if (usePlatformOptimizations) { // create specialized instance
 #if defined(OGLES_GPGPU_IOS) && !defined(OGLES_GPGPU_OPENGL_ES3)
-        instance = (MemTransfer*)new MemTransferIOS();
+        instance = std::unique_ptr<MemTransfer>(new MemTransferIOS);
 #elif defined(OGLES_GPGPU_ANDROID) && !defined(OGLES_GPGPU_OPENGL_ES3)
-        instance = (MemTransfer*)new MemTransferAndroid();
+        instance = std::unique_ptr<MemTransfer>(new MemTransferAndroid);
 #else
-        instance = (MemTransfer*)new MemTransfer();
+        instance = std::unique_ptr<MemTransfer>(new MemTransfer);
 #endif
     }
 
     if (!instance) { // create default instance
-        instance = new MemTransfer();
+        instance = std::unique_ptr<MemTransfer>(new MemTransfer);
     }
 
     return instance;

--- a/ogles_gpgpu/common/gl/memtransfer_factory.h
+++ b/ogles_gpgpu/common/gl/memtransfer_factory.h
@@ -18,6 +18,8 @@
 #include "../common_includes.h"
 #include "memtransfer.h"
 
+#include <memory>
+
 namespace ogles_gpgpu {
 
 /**
@@ -29,7 +31,7 @@ public:
     /**
      * Create a new MemTransfer instance.
      */
-    static MemTransfer* createInstance();
+    static std::unique_ptr<MemTransfer> createInstance();
 
     /**
      * Try to enable platform optimizations. Returns true on success, else false.

--- a/ogles_gpgpu/common/proc/base/filterprocbase.cpp
+++ b/ogles_gpgpu/common/proc/base/filterprocbase.cpp
@@ -204,8 +204,6 @@ void FilterProcBase::filterRenderPrepare() {
     // set the viewport
     glViewport(0, 0, outFrameW, outFrameH);
 
-    assert(texTarget == GL_TEXTURE_2D); // texTarget = GL_TEXTURE_2D;
-
     // set input texture
     glActiveTexture(GL_TEXTURE0 + texUnit);
     glBindTexture(texTarget, texId); // bind input texture

--- a/ogles_gpgpu/common/proc/base/procbase.h
+++ b/ogles_gpgpu/common/proc/base/procbase.h
@@ -20,6 +20,8 @@
 #include "../../gl/memtransfer.h"
 #include "../../gl/shader.h"
 
+#include <memory>
+
 #define OGLES_GPGPU_QUAD_VERTICES 4
 #define OGLES_GPGPU_QUAD_COORDS_PER_VERTEX 3
 #define OGLES_GPGPU_QUAD_TEXCOORDS_PER_VERTEX 2
@@ -226,8 +228,8 @@ protected:
     static const GLfloat quadTexCoordsDiagonalMirrored[]; // diagonal mirrored quad texture coordinates
     static const GLfloat quadVertices[]; // default quad vertices
 
-    FBO* fbo; // strong ref.!
-    Shader* shader; // strong ref.!
+    std::unique_ptr<FBO> fbo; // strong ref.!
+    std::unique_ptr<Shader> shader; // strong ref.!
 
     unsigned int orderNum; // position of this processor in the pipeline
 

--- a/ogles_gpgpu/common/proc/base/procinterface.cpp
+++ b/ogles_gpgpu/common/proc/base/procinterface.cpp
@@ -8,27 +8,27 @@ void ProcInterface::setOutputPboCount(int count) {
     outputPboCount = count;
 }
 
-void ProcInterface::setPreProcessCallback(ProcDelegate& cb) {
+void ProcInterface::setPreProcessCallback(const ProcDelegate& cb) {
     m_preProcessCallback = cb;
 }
 
-void ProcInterface::setPostProcessCallback(ProcDelegate& cb) {
+void ProcInterface::setPostProcessCallback(const ProcDelegate& cb) {
     m_postProcessCallback = cb;
 }
 
-void ProcInterface::setPreRenderCallback(ProcDelegate& cb) {
+void ProcInterface::setPreRenderCallback(const ProcDelegate& cb) {
     m_preRenderCallback = cb;
 }
 
-void ProcInterface::setPostRenderCallback(ProcDelegate& cb) {
+void ProcInterface::setPostRenderCallback(const ProcDelegate& cb) {
     m_postRenderCallback = cb;
 }
 
-void ProcInterface::setPreInitCallback(ProcDelegate& cb) {
+void ProcInterface::setPreInitCallback(const ProcDelegate& cb) {
     m_preInitCallback = cb;
 }
 
-void ProcInterface::setPostInitCallback(ProcDelegate& cb) {
+void ProcInterface::setPostInitCallback(const ProcDelegate& cb) {
     m_postInitCallback = cb;
 }
 
@@ -86,8 +86,8 @@ void ProcInterface::process(GLuint id, GLuint useTexUnit, GLenum target, int ind
         }
     }
 
-    if (m_postRenderCallback) {
-        m_postRenderCallback(this);
+    if (m_postProcessCallback) {
+        m_postProcessCallback(this);
     }
 }
 

--- a/ogles_gpgpu/common/proc/base/procinterface.h
+++ b/ogles_gpgpu/common/proc/base/procinterface.h
@@ -264,32 +264,32 @@ public:
     /**
      * Set a pre processing callback
      */
-    virtual void setPreProcessCallback(ProcDelegate& cb);
+    virtual void setPreProcessCallback(const ProcDelegate& cb);
 
     /**
      * Set a pre processing callback
      */
-    virtual void setPostProcessCallback(ProcDelegate& cb);
+    virtual void setPostProcessCallback(const ProcDelegate& cb);
 
     /**
      * Set a pre render callback
      */
-    virtual void setPreRenderCallback(ProcDelegate& cb);
+    virtual void setPreRenderCallback(const ProcDelegate& cb);
 
     /**
      * Set a post render callback
      */
-    virtual void setPostRenderCallback(ProcDelegate& cb);
+    virtual void setPostRenderCallback(const ProcDelegate& cb);
 
     /**
      * Set a pre init callback
      */
-    virtual void setPreInitCallback(ProcDelegate& cb);
+    virtual void setPreInitCallback(const ProcDelegate& cb);
 
     /**
      * Set a post init callback
      */
-    virtual void setPostInitCallback(ProcDelegate& cb);
+    virtual void setPostInitCallback(const ProcDelegate& cb);
 
 protected:
     /**

--- a/ogles_gpgpu/common/proc/disp.h
+++ b/ogles_gpgpu/common/proc/disp.h
@@ -68,29 +68,22 @@ public:
     /**
      * Not implemented - no output texture needed because Disp renders on screen.
      */
-    virtual void createFBOTex(bool genMipmap) {
-        assert(false);
-    }
+    virtual void createFBOTex(bool genMipmap) {}
 
     /**
      * Not implemented - no output is returned because Disp renders on screen.
      */
-    virtual void getResultData(unsigned char* data = nullptr, int index = 0) const {
-        assert(false);
-    }
+    virtual void getResultData(unsigned char* data = nullptr, int index = 0) const {} 
 
     /**
      * Not implemented - no output is returned because Disp renders on screen.
      */
-    virtual void getResultData(const FrameDelegate& frameDelegate = {}, int index = 0) const {
-        assert(false);
-    }
+    virtual void getResultData(const FrameDelegate& frameDelegate = {}, int index = 0) const {}
 
     /**
      * Not implemented - no MemTransferObj for output is set because Disp renders on screen.
      */
     virtual MemTransfer* getMemTransferObj() const {
-        assert(false);
         return NULL;
     }
 

--- a/ogles_gpgpu/common/proc/video.cpp
+++ b/ogles_gpgpu/common/proc/video.cpp
@@ -56,7 +56,6 @@ void VideoSource::configurePipeline(const Size2d& size, GLenum inputPixFormat) {
         yuv2RgbProc->createFBOTex(false); // TODO: mipmapping?
     }
 
-    assert(pipeline);
     if (pipeline != nullptr) {
         pipeline->prepare(size.width, size.height, inputPixFormat);
     }

--- a/ogles_gpgpu/platform/android/fake_dlfcn.c
+++ b/ogles_gpgpu/platform/android/fake_dlfcn.c
@@ -21,7 +21,10 @@
 */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <fcntl.h>
+#include <unistd.h> // for close
 #include <sys/mman.h>
 #include <elf.h>
 #include <android/log.h>

--- a/ogles_gpgpu/platform/opengl/gl_includes.h
+++ b/ogles_gpgpu/platform/opengl/gl_includes.h
@@ -28,6 +28,7 @@
 #    if defined(OGLES_GPGPU_OPENGL_ES3)
 #      include <OpenGLES/ES3/gl.h>
 #      include <OpenGLES/ES3/glext.h>
+#      include <OpenGLES/ES2/glext2.h>
 #    else
 #      include <OpenGLES/ES2/gl.h>
 #      include <OpenGLES/ES2/glext.h>
@@ -35,7 +36,7 @@
 #  else
 #    if defined(OGLES_GPGPU_OPENGL_ES3)
 #      include <OpenGL/gl3.h>
-#      include <OpenGL/gl3ext.h>
+#      include <OpenGL/gl2ext.h>
 #    else
 #      include <OpenGL/gl.h>
 #      include <OpenGL/glext.h>
@@ -43,8 +44,22 @@
 #  endif
 #elif defined(__ANDROID__) || defined(ANDROID)
 #  if defined(OGLES_GPGPU_OPENGL_ES3)
+// ::: https://stackoverflow.com/q/31003863 :::
+// According to the Khronos OpenGL ES Registry, the extension header for 
+// GLES 3.0 is actually <GLES2/gl2ext.h>.  gl3ext.h should be empty and 
+// provided only for legacy compatibility. Thus, if you want to include 
+// GLES 3.0 headers, you should do:
+//
+// ::: https://stackoverflow.com/a/31025110 :::
+// ...this is fixed in API-21. However, if you still need 
+// to use API-18 or API-19, there is a work-around. You can simply:
+// [define __gl2_h_] when gl2ext.h includes gl2.h, the defined include 
+// guard will cause the contents of gl2.h to be skipped.
+#     if __ANDROID_API__ < 21
+#       define __gl2_h_
+#     endif
 #    include <GLES3/gl3.h>
-#    include <GLES3/gl3ext.h>
+#    include <GLES2/gl2ext.h>  // GL_TEXTURE_EXTERNAL_OES, etc
 #  else
 #    include <GLES2/gl2.h>
 #    include <GLES2/gl2ext.h>

--- a/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
+++ b/ogles_gpgpu/ut/test-ogles_gpgpu.cpp
@@ -157,6 +157,11 @@ bool almost_equal(const cv::Mat_<cv::Vec<T,N>> &a, const cv::Mat_<cv::Vec<T,N>> 
 static cv::Vec3f cvtColorRgb2Luv(const cv::Vec3f& rgb);
 
 int gauze_main(int argc, char** argv) {
+
+    // You can enable platform specific optimizations for faster transfers,
+    // althought this is insignificant for unit testing.
+    //ogles_gpgpu::Core::tryEnablePlatformOptimizations();
+    
     ::testing::InitGoogleTest(&argc, argv);
     auto code = RUN_ALL_TESTS();
     return code;
@@ -339,7 +344,7 @@ TEST(OGLESGPGPUTest, Rgb2LuvProc) {
             cv::Vec3b rgb = torgb(cv::Vec3b(in[0], in[1], in[2]));
             cv::Vec3b luv = cvtColorRgb2Luv(cv::Vec3f(rgb) * (1.0/255.0)) * 255.0;
 
-            ASSERT_LE(max_element(cv::absdiff(cv::Vec3b(out[0],out[1],out[2]), luv)), 1);
+            ASSERT_LE(max_element(cv::absdiff(cv::Vec3b(out[0],out[1],out[2]), luv)), 2);
         }
     }
 }


### PR DESCRIPTION
NOTE: After PR is merged the version will be bumped and the check_ci_tag will be enabled.

* fix android gl2ext.h usage (with extensive comments) in OpenGL ES 3.0 cases on android (#define __gl2_h workaround)
* add comment block for ogles_gpgpu::Core::tryEnablePlatformOptimizations() in unit test to provide an optional user hint
* add explicit header includes to avoid warnings on android
* fix “fake” dlopen implementation
    + add FILE pointer handle and parsing for `popen("getprop ro.build.version.sdk", “r”)` in cases where ANDROID_API<21
    + add headers to fake_dlfcn to avoid warnings
* relax rgb2luv test case by 1 pixel, this can vary slightly between gpus
* replace internal ogles_gpgpu shader/filter dynamic allocations w/ unique_ptr<T>
* update hunter
* make procinterface pipeline std::function<> checkpoint callbacks const for direct assignment
* remove GL_TEXTURE_2D assumption, as enforced by various  development assertions (my fault)
* include ES2/glext2.h when using ES3 (see above)
* disp: remove some asserts — even though some virtual api calls are invalid for disp we shouldn’t assert in cases where it is the tail end of a filter chain that is recursive initialized (see prepare())
* video: remove assert — we should not assert(pipeline) in the video constructor
* translate python cache update to native hunter calls