### PR TITLE
opengl es 3 header fix for osx

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,12 +1,13 @@
+option(OGLES_GPGPU_OPENCV_HIGHGUI "Toggle opencv highgui" OFF)
 set(OPENCV_CMAKE_ARGS
 
   BUILD_opencv_core=ON
   BUILD_opencv_imgproc=ON
   
-  BUILD_opencv_imgcodecs=OFF
-  BUILD_opencv_video=OFF
-  BUILD_opencv_videoio=OFF
-  BUILD_opencv_highgui=OFF  
+  BUILD_opencv_imgcodecs=${OGLES_GPGPU_OPENCV_HIGHGUI}
+  BUILD_opencv_video=${OGLES_GPGPU_OPENCV_HIGHGUI}
+  BUILD_opencv_videoio=${OGLES_GPGPU_OPENCV_HIGHGUI}
+  BUILD_opencv_highgui=${OGLES_GPGPU_OPENCV_HIGHGUI}
   
   BUILD_opencv_calib3d=OFF
   BUILD_opencv_contrib=OFF

--- a/ogles_gpgpu/common/proc/video.cpp
+++ b/ogles_gpgpu/common/proc/video.cpp
@@ -99,7 +99,6 @@ void VideoSource::operator()(const Size2d& size, void* pixelBuffer, bool useRawP
 
             yuv2RgbProc->setTextures(manager->getLuminanceTexId(), manager->getChrominanceTexId());
             yuv2RgbProc->render();
-            //glFinish();
 
             gpgpuInputHandler->prepareInput(frameSize.width, frameSize.height, GL_NONE, nullptr);
             inputTexture = yuv2RgbProc->getOutputTexId(); // override input parameter

--- a/ogles_gpgpu/platform/opengl/gl_includes.h
+++ b/ogles_gpgpu/platform/opengl/gl_includes.h
@@ -36,7 +36,7 @@
 #  else
 #    if defined(OGLES_GPGPU_OPENGL_ES3)
 #      include <OpenGL/gl3.h>
-#      include <OpenGL/gl2ext.h>
+#      include <OpenGL/gl3ext.h>
 #    else
 #      include <OpenGL/gl.h>
 #      include <OpenGL/glext.h>


### PR DESCRIPTION
* fix osx opengl es 3 (compatible) header include  
  + NEW <OpenGL/gl3ext.h>
  + OLD <OpenGL/gl2ext.h>
* add config cmake option to toggle opencv highgui build