### PR TITLE
encapsulate GPUImage yuv2rgb variables in namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,15 @@ dist:
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
+      - llvm-toolchain-trusty-5.0
     packages:
       # For ogles_gpgpu (GL library)
       - libgl1-mesa-dev
       - libegl1-mesa-dev
       - libosmesa6-dev      
 
-      # GCC 7
-      - g++-7
+      # clang 5
+      - clang-5.0
 
       # pip3
       - python3-pip
@@ -43,20 +43,20 @@ matrix:
 
     - os: linux
       env: >
-        TOOLCHAIN=gcc-7
+        TOOLCHAIN=clang-5
         CONFIG=Release
         INSTALL=--strip
         MESA=ON
 
+    # FIXME: OSError: [Errno 28] No space left on device
+    # - os: linux
+    #   env: >
+    #     TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
+    #     CONFIG=MinSizeRel
+    #     INSTALL=--strip
+    #     MESA=OFF
+    #     TEST=--test
 
-    - os: linux
-      env: >
-        TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
-        CONFIG=MinSizeRel
-        INSTALL=--strip
-        MESA=OFF
-        TEST=--test
-        
     # }
 
     # OSX {
@@ -79,6 +79,13 @@ matrix:
         CONFIG=Release
         INSTALL=--install
         MESA=OFF
+
+    - os: osx
+      env: >        
+        TOOLCHAIN=android-ndk-r17-api-19-armeabi-v7a-neon-clang-libcxx
+        CONFIG=Release
+        INSTALL=--install
+        MESA=OFF        
 
     # }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,8 @@ install:
   - export HOMEBREW_NO_AUTO_UPDATE=1
 
   # Install Python 3
-  - if [[ "`uname`" == "Darwin" ]]; then travis_retry brew upgrade python; fi
+  # >> Error: python 2.7.14 is already installed \n To upgrade to 3.6.4_3, run `brew upgrade python`
+  #- if [[ "`uname`" == "Darwin" ]]; then travis_retry brew upgrade python; fi
   - if [[ "`uname`" == "Darwin" ]]; then travis_retry brew install python3; fi
 
   # Install Python package 'requests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,8 +108,8 @@ install:
 
   # Install Python 3
   # >> Error: python 2.7.14 is already installed \n To upgrade to 3.6.4_3, run `brew upgrade python`
-  #- if [[ "`uname`" == "Darwin" ]]; then travis_retry brew upgrade python; fi
-  - if [[ "`uname`" == "Darwin" ]]; then travis_retry brew install python3; fi
+  #- if [[ "`uname`" == "Darwin" ]]; then travis_retry brew install python3; fi  
+  - if [[ "`uname`" == "Darwin" ]]; then travis_retry brew upgrade python; fi
 
   # Install Python package 'requests'
   # 'easy_install3' is not installed by 'brew install python3' on OS X 10.9 Maverick

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,15 +43,16 @@ matrix:
 
     - os: linux
       env: >
-        TOOLCHAIN=gcc-5-pic-hid-sections
+        TOOLCHAIN=gcc-5
         CONFIG=Release
         INSTALL=--strip
         MESA=ON
 
+
     - os: linux
       env: >
         TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
-        CONFIG=Release
+        CONFIG=MinSizeRel
         INSTALL=--strip
         MESA=OFF
         TEST=--test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # OSX/Linux (https://github.com/travis-ci-tester/toolchain-table)
 
 language:
-  - cpp
+  - minimal
 
 # Container-based infrastructure (Linux)
 # * https://docs.travis-ci.com/user/migrating-from-legacy/#How-can-I-use-container-based-infrastructure%3F
@@ -27,8 +27,8 @@ addons:
       - libegl1-mesa-dev
       - libosmesa6-dev      
 
-      # GCC 5
-      - g++-5
+      # GCC 7
+      - g++-7
 
       # pip3
       - python3-pip
@@ -43,7 +43,7 @@ matrix:
 
     - os: linux
       env: >
-        TOOLCHAIN=gcc-5
+        TOOLCHAIN=gcc-7
         CONFIG=Release
         INSTALL=--strip
         MESA=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 # OSX/Linux (https://github.com/travis-ci-tester/toolchain-table)
 
-# Original: https://github.com/forexample/hunter-simple/blob/master/.travis.yml
-
-# Workaround for https://github.com/travis-ci/travis-ci/issues/8363
 language:
-  - minimal
+  - cpp
 
 # Container-based infrastructure (Linux)
 # * https://docs.travis-ci.com/user/migrating-from-legacy/#How-can-I-use-container-based-infrastructure%3F
@@ -16,33 +13,23 @@ dist:
 
 # Install packages differs for container-based infrastructure
 # * https://docs.travis-ci.com/user/migrating-from-legacy/#How-do-I-install-APT-sources-and-packages%3F
+# List of available packages:
+# * https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-trusty
+# List of available sources:
+# * https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      # For off screen rendering
-      - libegl1-mesa-dev
-      - libosmesa6-dev
-
-      # glapi
+      # For ogles_gpgpu (GL library)
       - libgl1-mesa-dev
 
-      # xorg-macros: https://github.com/BlueDragonX/xf86-input-mtrack/issues/27#issuecomment-186871891
-      - xutils-dev
-      - xserver-xorg-dev-lts-trusty
+      # GCC 5
+      - g++-5
 
-      # Packages for Android development: http://superuser.com/a/360398/252568
-      - libncurses5:i386
-      - libstdc++6:i386
-      - zlib1g:i386
-
+      # pip3
       - python3-pip
-
-      # Default GCC 4.8 is buggy:
-      # * https://github.com/elucideye/drishti/issues/273#issuecomment-301297286
-      #- g++-5
-      #- gcc-5
 
 env:
   global:
@@ -53,8 +40,20 @@ matrix:
     # Linux {
 
     - os: linux
-      env: CONFIG=Release TOOLCHAIN=gcc INSTALL=--strip MESA=ON TEST=--test
+      env: >
+        TOOLCHAIN=gcc-5-pic-hid-sections
+        CONFIG=Release
+        INSTALL=--strip
+        MESA=ON
 
+    - os: linux
+      env: >
+        TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
+        CONFIG=Release
+        INSTALL=--strip
+        MESA=OFF
+        TEST=--test
+        
     # }
 
     # OSX {
@@ -63,16 +62,20 @@ matrix:
     # https://github.com/ingenue/hunter/blob/pkg.opencv/.travis.yml
 
     - os: osx
-      osx_image: xcode8.3
-      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-10-3-arm64-dep-9-0-device-libcxx-hid-sections INSTALL=--install MESA=OFF
+      osx_image: xcode9.3
+      env: >
+        TOOLCHAIN=ios-nocodesign-11-3-dep-9-3-arm64
+        CONFIG=Release
+        INSTALL=--install
+        MESA=OFF
 
     - os: osx
-      osx_image: xcode8.3
-      env: CONFIG=Release TOOLCHAIN=osx-10-12 INSTALL=--install MESA=OFF
-
-    - os: osx
-      osx_image: xcode8.3
-      env: CONFIG=Release TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon INSTALL=--strip MESA=OFF TEST=--test
+      osx_image: xcode9.3
+      env: >
+        TOOLCHAIN=osx-10-13
+        CONFIG=Release
+        INSTALL=--install
+        MESA=OFF
 
     # }
 
@@ -82,14 +85,19 @@ before_install:
   - git submodule update --init --recursive --quiet
 
 install:
+
   # Info about OS
   - uname -a
+
+  # Info about available disk space
+  - df -h $HOME
 
   # Disable autoupdate
   # * https://github.com/Homebrew/brew/blob/7d31a70373edae4d8e78d91a4cbc05324bebc3ba/Library/Homebrew/manpages/brew.1.md.erb#L202
   - export HOMEBREW_NO_AUTO_UPDATE=1
 
   # Install Python 3
+  - if [[ "`uname`" == "Darwin" ]]; then travis_retry brew upgrade python; fi
   - if [[ "`uname`" == "Darwin" ]]; then travis_retry brew install python3; fi
 
   # Install Python package 'requests'
@@ -113,20 +121,23 @@ install:
 
   # Installed if toolchain is Android (otherwise directory doesn't exist)
   - export ANDROID_NDK_r10e="`pwd`/_ci/android-ndk-r10e"
+  - export ANDROID_NDK_r11c="`pwd`/_ci/android-ndk-r11c"
+  - export ANDROID_NDK_r15c="`pwd`/_ci/android-ndk-r15c"
+  - export ANDROID_NDK_r16b="`pwd`/_ci/android-ndk-r16b"
+  - export ANDROID_NDK_r17="`pwd`/_ci/android-ndk-r17"
 
 script:
 
   - >
     polly.py
     --toolchain ${TOOLCHAIN}
-    --config ${CONFIG}
+    --config-all ${CONFIG}
     --verbose
     --ios-multiarch --ios-combined
     --fwd HUNTER_CONFIGURATION_TYPES=${CONFIG}
     OGLES_GPGPU_BUILD_TESTS=ON
     OGLES_GPGPU_USE_OSMESA=${MESA}
     GAUZE_ANDROID_USE_EMULATOR=YES
-    HUNTER_CONFIGURATION_TYPES=${CONFIG}
     HUNTER_SUPPRESS_LIST_OF_FILES=ON
     --jobs 2
     ${INSTALL} ${TEST}

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ addons:
     packages:
       # For ogles_gpgpu (GL library)
       - libgl1-mesa-dev
+      - libegl1-mesa-dev
+      - libosmesa6-dev      
 
       # GCC 5
       - g++-5

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ matrix:
         MESA=OFF
 
     - os: osx
+      osx_image: xcode9.3 # https://travis-ci.org/hunter-packages/ogles_gpgpu/jobs/391926546#L54
       env: >        
         TOOLCHAIN=android-ndk-r17-api-19-armeabi-v7a-neon-clang-libcxx
         CONFIG=Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,12 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-  URL "https://github.com/ruslo/hunter/archive/v0.21.9.tar.gz"
-  SHA1 "0056188988906abb63a06c6f1aaef01832c62b74"
+  URL "https://github.com/ruslo/hunter/archive/v0.22.13.tar.gz"
+  SHA1 "8b361d14d17c3526d41ecb62b6e905bdd9f3ee1d"
   LOCAL
 )
 
-project(ogles_gpgpu VERSION 0.2.10)
+project(ogles_gpgpu VERSION 0.2.11)
 
 hunter_add_package(check_ci_tag)
 find_package(check_ci_tag CONFIG REQUIRED)

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,124 +1,14 @@
-option(OGLES_GPGPU_OPENCV_HIGHGUI "Toggle opencv highgui" OFF)
 set(OPENCV_CMAKE_ARGS
-
-  BUILD_opencv_core=ON
-  BUILD_opencv_imgproc=ON
-  
-  BUILD_opencv_imgcodecs=${OGLES_GPGPU_OPENCV_HIGHGUI}
-  BUILD_opencv_video=${OGLES_GPGPU_OPENCV_HIGHGUI}
-  BUILD_opencv_videoio=${OGLES_GPGPU_OPENCV_HIGHGUI}
-  BUILD_opencv_highgui=${OGLES_GPGPU_OPENCV_HIGHGUI}
-  
-  BUILD_opencv_calib3d=OFF
-  BUILD_opencv_contrib=OFF
-  BUILD_opencv_cudaarithm=OFF
-  BUILD_opencv_cudabgsegm=OFF
-  BUILD_opencv_cudacodec=OFF
-  BUILD_opencv_cudafeatures2d=OFF
-  BUILD_opencv_cudafilters=OFF
-  BUILD_opencv_cudaimgproc=OFF
-  BUILD_opencv_cudalegacy=OFF
-  BUILD_opencv_cudaobjdetect=OFF
-  BUILD_opencv_cudaoptflow=OFF
-  BUILD_opencv_cudastereo=OFF
-  BUILD_opencv_cudawarping=OFF
-  BUILD_opencv_cudev=OFF
-  BUILD_opencv_features2d=OFF
-  BUILD_opencv_flann=OFF
-  BUILD_opencv_gpu=OFF
-  BUILD_opencv_java=OFF
-  BUILD_opencv_legacy=OFF
-  BUILD_opencv_ml=OFF
-  BUILD_opencv_nonfree=OFF
-  BUILD_opencv_objdetect=OFF
-  BUILD_opencv_ocl=OFF
-  BUILD_opencv_photo=OFF
-  BUILD_opencv_python=OFF
-  BUILD_opencv_shape=OFF
-  BUILD_opencv_stitching=OFF
-  BUILD_opencv_superres=OFF
-  BUILD_opencv_ts=OFF
-  BUILD_opencv_videostab=OFF
-  BUILD_opencv_viz=OFF
-  BUILD_opencv_world=OFF
-  BUILD_opencv_apps=OFF  
-  
-  BUILD_DOCS=OFF
-  BUILD_TESTS=OFF
-  BUILD_PERF_TESTS=OFF
-  BUILD_EXAMPLES=OFF
-  ENABLE_NEON=OFF
-  BUILD_ANDROID_SERVICE=OFF
-  BUILD_ANDROID_EXAMPLES=OFF
-  BUILD_ZLIB=OFF ## HUNTER
-  BUILD_TIFF=OFF ## HUNTER
-  BUILD_PNG=OFF  ## HUNTER
-  BUILD_JPEG=OFF ## HUNTER
-  ANDROID_EXAMPLES_WITH_LIBS=OFF    # "Build binaries of Android examples with native libraries"
-
-  ### Custom ARGS ###
-  WITH_PNG=OFF             # "Include PNG support"
-  WITH_TIFF=OFF           # "Include TIFF support"
-  WITH_JASPER=OFF          # "Include JPEG2K support"
-  WITH_JPEG=OFF            # "Include JPEG support"
-
-  WITH_OPENCL=NO
-  HAVE_OPENCL=NO
-  HAVE_EIGEN=NO
-  HAVE_CUFFT=NO
-  HAVE_CUBLAS=NO
-  HAVE_CUDA=NO
-
-  WITH_QTKIT=NO
-
-  WITH_PTHREADS_PF=OFF    # "Use pthreads-based parallel_for"
-  WITH_TBB=OFF            # "Include Intel TBB support"
-  WITH_1394=OFF           # "Include IEEE1394 support"
-  WITH_AVFOUNDATION=OFF   # "Use AVFoundation for Video I/O"
-  WITH_CARBON=OFF         # "Use Carbon for UI instead of Cocoa"
-  WITH_VTK=OFF            # "Include VTK library support (and build opencv_viz module eiher)"
-  WITH_CUDA=OFF           # "Include NVidia Cuda Runtime support"
-  WITH_CUFFT=OFF          # "Include NVidia Cuda Fast Fourier Transform (FFT) library support"
-  WITH_CUBLAS=OFF         # "Include NVidia Cuda Basic Linear Algebra Subprograms (BLAS) library support"
-  WITH_NVCUVID=OFF        # "Include NVidia Video Decoding library support"
-  WITH_EIGEN=OFF          # "Include Eigen2/Eigen3 support"
-  WITH_VFW=OFF            # "Include Video for Windows support"
-  WITH_FFMPEG=OFF         # "Include FFMPEG support"
-  WITH_GSTREAMER=OFF      # "Include Gstreamer support"
-  WITH_GSTREAMER_0_10=OFF # "Enable Gstreamer 0.10 support (instead of 1.x)"
-  WITH_GTK=OFF            # "Include GTK support"
-  WITH_GTK_2_X=OFF        # "Use GTK version 2"
-  WITH_IPP=OFF            # "Include Intel IPP support"
-  WITH_WEBP=OFF           # "Include WebP support"
-  WITH_OPENEXR=OFF        # "Include ILM support via OpenEXR"
-  WITH_OPENGL=OFF         # "Include OpenGL support"
-  WITH_OPENNI=OFF         # "Include OpenNI support"
-  WITH_OPENNI2=OFF        # "Include OpenNI2 support"
-  WITH_PVAPI=OFF          # "Include Prosilica GigE support"
-  WITH_GIGEAPI=OFF        # "Include Smartek GigE support"
-  WITH_QT=OFF             # "Build with Qt Backend support"
-  WITH_WIN32UI=OFF        # "Build with Win32 UI Backend support"
-  WITH_QUICKTIME=OFF      # "Use QuickTime for Video I/O insted of QTKit"
-  WITH_OPENMP=OFF         # "Include OpenMP support"
-  WITH_CSTRIPES=OFF       # "Include C= support"
-  WITH_UNICAP=OFF         # "Include Unicap support (GPL)"
-  WITH_V4L=OFF            # "Include Video 4 Linux support"
-  WITH_LIBV4L=OFF         # "Use libv4l for Video 4 Linux support"
-  WITH_DSHOW=OFF          # "Build VideoIO with DirectShow support"
-  WITH_MSMF=OFF           # "Build VideoIO with Media Foundation support"
-  WITH_XIMEA=OFF          # "Include XIMEA cameras support"
-  WITH_XINE=OFF           # "Include Xine support (GPL)"
-  WITH_CLP=OFF            # "Include Clp support (EPL)"
-  WITH_OPENCL=OFF         # "Include OpenCL Runtime support"
-  WITH_OPENCL_SVM=OFF     # "Include OpenCL Shared Virtual Memory support"
-  WITH_OPENCLAMDFFT=OFF   # "Include AMD OpenCL FFT library support"
-  WITH_OPENCLAMDBLAS=OFF  # "Include AMD OpenCL BLAS library support"
-  WITH_DIRECTX=OFF        # "Include DirectX support"
-  WITH_INTELPERC=OFF      # "Include Intel Perceptual Computing support"
-  WITH_IPP_A=OFF          # "Include Intel IPP_A support"
-  WITH_GDAL=OFF           # "Include GDAL Support"
-  WITH_GPHOTO2=OFF        # "Include gPhoto2 library support"
-  )
+  WITH_JASPER=OFF
+  BUILD_JASPER=OFF
+  WITH_WEBP=OFF
+  BUILD_WEBP=OFF
+  WITH_OPENEXR=OFF
+  BUILD_OPENEXR=OFF
+  BUILD_PROTOBUF=OFF   #  -/-
+  BUILD_LIBPROTOBUF_FROM_SOURCES=NO    
+  BUILD_LIST=core,imgproc,videoio,highgui
+)
 
 # Try to build very small OpenCV to support unit tests
 hunter_config(OpenCV VERSION ${HUNTER_OpenCV_VERSION} CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")

--- a/ogles_gpgpu/common/proc/yuv2rgb.cpp
+++ b/ogles_gpgpu/common/proc/yuv2rgb.cpp
@@ -10,8 +10,7 @@
 #include "yuv2rgb.h"
 #include "../common_includes.h"
 
-using namespace std;
-using namespace ogles_gpgpu;
+BEGIN_OGLES_GPGPU
 
 // Color Conversion Constants (YUV to RGB) including adjustment from 16-235/16-240 (video range)
 
@@ -360,3 +359,5 @@ int Yuv2RgbProc::render(int position) {
 
     return 0;
 }
+
+END_OGLES_GPGPU

--- a/ogles_gpgpu/common/proc/yuv2rgb.h
+++ b/ogles_gpgpu/common/proc/yuv2rgb.h
@@ -16,7 +16,7 @@
 
 #include "base/filterprocbase.h"
 
-namespace ogles_gpgpu {
+BEGIN_OGLES_GPGPU
 
 /**
  * GPGPU yuv2rgb processor will perform yuv to rgb colorspace transformation
@@ -102,6 +102,7 @@ private:
     YUVKind yuvKind = k601VideoRange;
     ChannelKind channelKind = kLA;
 };
-}
+
+END_OGLES_GPGPU
 
 #endif


### PR DESCRIPTION
* encapsulate GPUImage yuv2rgb shader variables in ogles_gpgpu namespace — these were copied from the GPUImage library and cause ODR conflicts if both ogles_gpgpu::ogles_gpgpu (really ogles_gpgpu::Yuv2RgbProc) and GPUImage::gpuimage symbols are linked
* use standard {BEGIN,END}_OGLES_GPGPU namespace macro
* update Hunter and simplify minimal opencv used for testing via BUILD_LIST feature
* bump patch version to v0.2.11