### PR TITLE
add VideoSource::configure()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ HunterGate(
   LOCAL
 )
 
-project(ogles_gpgpu VERSION 0.2.11)
+project(ogles_gpgpu VERSION 0.3.0)
 
 hunter_add_package(check_ci_tag)
 find_package(check_ci_tag CONFIG REQUIRED)

--- a/ogles_gpgpu/common/proc/video.cpp
+++ b/ogles_gpgpu/common/proc/video.cpp
@@ -70,6 +70,15 @@ void VideoSource::operator()(const FrameInput& frame) {
     return (*this)(frame.size, frame.pixelBuffer, frame.useRawPixels, frame.inputTexture, frame.textureFormat);
 }
 
+void VideoSource::configure(const Size2d& size, GLenum inputPixFormat)
+{
+    if (firstFrame || size != frameSize)
+    {
+        configurePipeline(size, inputPixFormat);
+        firstFrame = false;
+    }
+}
+
 void VideoSource::operator()(const Size2d& size, void* pixelBuffer, bool useRawPixels, GLuint inputTexture, GLenum inputPixFormat) {
     preConfig();
 
@@ -77,6 +86,8 @@ void VideoSource::operator()(const Size2d& size, void* pixelBuffer, bool useRawP
         m_timer("begin");
 
     assert(pipeline);
+
+    configure(size, inputPixFormat);
 
     if (firstFrame || size != frameSize) {
         configurePipeline(size, inputPixFormat);

--- a/ogles_gpgpu/common/proc/video.h
+++ b/ogles_gpgpu/common/proc/video.h
@@ -62,6 +62,8 @@ public:
 
     void init(void* glContext);
 
+    void configure(const Size2d& size, GLenum inputPixFormat = DFLT_PIX_FORMAT);
+
     void operator()(const FrameInput& frame);
 
     void operator()(const Size2d& size, void* pixelBuffer, bool useRawPixels, GLuint inputTexture = 0, GLenum inputPixFormat = DFLT_PIX_FORMAT);


### PR DESCRIPTION
… to support up-front initialization/pre-allocation of pipeline, instead of waiting to configure based on first input frame.  This avoid this need for a dummy frame.  Bump minor version for public api update.