### PR TITLE
fix BGRA CVPixelBufferRef input path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ HunterGate(
   LOCAL
 )
 
-project(ogles_gpgpu VERSION 0.3.1)
+project(ogles_gpgpu VERSION 0.3.2)
 
 hunter_add_package(check_ci_tag)
 find_package(check_ci_tag CONFIG REQUIRED)

--- a/ogles_gpgpu/common/proc/video.cpp
+++ b/ogles_gpgpu/common/proc/video.cpp
@@ -115,7 +115,6 @@ void VideoSource::operator()(const Size2d& size, void* pixelBuffer, bool useRawP
             inputTexture = yuv2RgbProc->getOutputTexId(); // override input parameter
         } else {
             gpgpuInputHandler->prepareInput(frameSize.width, frameSize.height, inputPixFormat, pixelBuffer);
-            setInputData(reinterpret_cast<const unsigned char*>(pixelBuffer));
             inputTexture = gpgpuInputHandler->getInputTexId(); // override input parameter
         }
     }


### PR DESCRIPTION
* remove spurious `setInputData()` call in VideoSource for `BGRA` CVPIxelBufferRef
* bump patch version to 0.3.2