### PR TITLE
fix `GL_{BGRA,RGBA}` for opt and non-opt  …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ HunterGate(
   LOCAL
 )
 
-project(ogles_gpgpu VERSION 0.3.2)
+project(ogles_gpgpu VERSION 0.3.3)
 
 hunter_add_package(check_ci_tag)
 find_package(check_ci_tag CONFIG REQUIRED)

--- a/ogles_gpgpu/common/proc/video.cpp
+++ b/ogles_gpgpu/common/proc/video.cpp
@@ -8,6 +8,7 @@
 
 #include "video.h"
 #include "yuv2rgb.h"
+#include <ogles_gpgpu/common/gl/memtransfer_optimized.h>
 
 using namespace ogles_gpgpu;
 
@@ -115,6 +116,12 @@ void VideoSource::operator()(const Size2d& size, void* pixelBuffer, bool useRawP
             inputTexture = yuv2RgbProc->getOutputTexId(); // override input parameter
         } else {
             gpgpuInputHandler->prepareInput(frameSize.width, frameSize.height, inputPixFormat, pixelBuffer);
+
+            // For generic platforms we must also load pixel buffer to the texture:
+            if (dynamic_cast<ogles_gpgpu::MemTransferOptimized*>(gpgpuInputHandler) == nullptr) {
+                setInputData(reinterpret_cast<const unsigned char*>(pixelBuffer));
+            }
+            
             inputTexture = gpgpuInputHandler->getInputTexId(); // override input parameter
         }
     }


### PR DESCRIPTION
The previous commit broke `GL_{BGRA,RGBA}` support for generic opengl back ends.

* check mode with `dynamic_cast<ogles_gpgpu::MemTransferOptimized*>(gpgpuInputHandler)`
* if using `GL_{RGBA,BGRA}` w/ optimized platform we don’t need `setInputData()`
* if using `GL_{RGBA,BGRA}` w/o optimized platforms an extra `setInputData()` step is required
* version @ v0.3.3