### PR TITLE
support renderbuffer based display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ HunterGate(
   LOCAL
 )
 
-project(ogles_gpgpu VERSION 0.3.3)
+project(ogles_gpgpu VERSION 0.3.4)
 
 hunter_add_package(check_ci_tag)
 find_package(check_ci_tag CONFIG REQUIRED)

--- a/ogles_gpgpu/common/proc/disp.h
+++ b/ogles_gpgpu/common/proc/disp.h
@@ -17,6 +17,8 @@
 
 #include "base/filterprocbase.h"
 
+#include <functional>
+
 namespace ogles_gpgpu {
 
 /**

--- a/ogles_gpgpu/common/proc/disp.h
+++ b/ogles_gpgpu/common/proc/disp.h
@@ -25,6 +25,24 @@ namespace ogles_gpgpu {
  */
 class Disp : public FilterProcBase {
 public:
+    
+    using Callback = std::function<void()>;
+    
+    /**
+     * Default constructor
+     */
+    Disp();
+    
+    /**
+     * Constructor for renderbuffer based display
+     */
+    Disp(const Callback &renderbufferStorage);
+
+    /**
+     * Destructor
+     */
+    virtual ~Disp();
+    
     /**
      * Output resolution of display.
      *
@@ -87,6 +105,13 @@ public:
         return NULL;
     }
 
+    /**
+     * Create an FBO for this processor. This will contain the result after rendering in its attached texture.
+     *
+     * (optional) create renderbuffer if renderbufferStorage callback was specified in constructor.
+     */
+    virtual void createFBO();
+    
 private:
     float tx = 0.f;
     float ty = 0.f;
@@ -94,6 +119,9 @@ private:
     float resolutionY = 1.f;
 
     static const char* fshaderDispSrc; // fragment shader source
+    
+    GLuint renderbuffer; // (optional) renderbuffer based display
+    Callback renderbufferStorage;
 };
 }
 


### PR DESCRIPTION
Add optional callback to Disp constructor to specify OS binding for renderbuffer storage during allocation.   If this is specified the renderbuffer will be used (via framebuffer) for rendering to the display, rather than framebuffer == 0 screen rendering.