### PR TITLE
add scope_guard for 'CFRelease(empty)' on iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ HunterGate(
   LOCAL
 )
 
-project(ogles_gpgpu VERSION 0.3.5)
+project(ogles_gpgpu VERSION 0.3.6)
 
 hunter_add_package(check_ci_tag)
 find_package(check_ci_tag CONFIG REQUIRED)

--- a/ogles_gpgpu/common/proc/fifo.cpp
+++ b/ogles_gpgpu/common/proc/fifo.cpp
@@ -112,7 +112,7 @@ void FifoProc::process(int position, Logger logger) {
 }
 
 ProcInterface* FifoProc::operator[](int i) const {
-    int index = modulo(m_outputIndex + i, procPasses.size());
+    int index = modulo(static_cast<int>(m_outputIndex) + i, static_cast<int>(procPasses.size()));
     return procPasses[index];
 }
 
@@ -192,13 +192,13 @@ void FifoProc::createFBOTex(bool genMipmap) {
 int FifoProc::render(int position) {
     // Render into input FBO
     if (m_count == int(size())) {
-        m_outputIndex = modulo(m_inputIndex + 1, size());
+        m_outputIndex = modulo(static_cast<int>(m_inputIndex) + 1, static_cast<int>(size()));
     }
 
     getInputFilter()->render();
 
     m_count = std::min(m_count + 1, int(size()));
-    m_inputIndex = modulo(m_inputIndex + 1, size());
+    m_inputIndex = modulo(static_cast<int>(m_inputIndex) + 1, static_cast<int>(size()));
 
     return 0;
 }

--- a/ogles_gpgpu/common/proc/mesh.cpp
+++ b/ogles_gpgpu/common/proc/mesh.cpp
@@ -117,7 +117,7 @@ void MeshShaderProc::filterRenderSetCoords() {
 }
 
 void MeshShaderProc::filterRenderDraw() {
-    glDrawArrays(triangleKind, 0, vertices.size());
+    glDrawArrays(triangleKind, 0, static_cast<int>(vertices.size()));
 }
 
 void MeshShaderProc::setTriangleKind(GLenum kind) {

--- a/ogles_gpgpu/common/proc/multipass/box_opt_pass.cpp
+++ b/ogles_gpgpu/common/proc/multipass/box_opt_pass.cpp
@@ -32,8 +32,8 @@ static std::string vertexShaderForOptimizedBoxBlur(int blurRadius, float sigma) 
     ss << "   vec2 singleStepOffset = vec2(texelWidthOffset, texelHeightOffset);\n";
     ss << "   blurCoordinates[0] = inputTextureCoordinate.xy;\n";
     for (int currentOptimizedOffset = 0; currentOptimizedOffset < numberOfOptimizedOffsets; currentOptimizedOffset++) {
-        int x1 = (unsigned long)((currentOptimizedOffset * 2) + 1);
-        int x2 = (unsigned long)((currentOptimizedOffset * 2) + 2);
+        int x1 = static_cast<int>((currentOptimizedOffset * 2) + 1);
+        int x2 = static_cast<int>((currentOptimizedOffset * 2) + 2);
 
         GLfloat optimizedOffset = (GLfloat)(currentOptimizedOffset * 2) + 1.5;
 
@@ -70,8 +70,8 @@ static std::string fragmentShaderForOptimizedBoxBlur(int blurRadius, float sigma
     ss << " sum += texture2D(inputImageTexture, blurCoordinates[0]) * " << boxWeight << ";\n";
 
     for (int currentBlurCoordinateIndex = 0; currentBlurCoordinateIndex < numberOfOptimizedOffsets; currentBlurCoordinateIndex++) {
-        int index1 = (unsigned long)((currentBlurCoordinateIndex * 2) + 1);
-        int index2 = (unsigned long)((currentBlurCoordinateIndex * 2) + 2);
+        int index1 = static_cast<int>((currentBlurCoordinateIndex * 2) + 1);
+        int index2 = static_cast<int>((currentBlurCoordinateIndex * 2) + 2);
         ss << "   sum += texture2D(inputImageTexture, blurCoordinates[" << index1 << "]) * " << boxWeight2 << ";\n";
         ss << "   sum += texture2D(inputImageTexture, blurCoordinates[" << index2 << "]) * " << boxWeight2 << ";\n";
     }

--- a/ogles_gpgpu/common/proc/multipass/gauss_opt_pass.cpp
+++ b/ogles_gpgpu/common/proc/multipass/gauss_opt_pass.cpp
@@ -77,8 +77,8 @@ std::string fragmentShaderForOptimizedBlur(int blurRadius, float sigma, bool doN
         GLfloat firstWeight = standardGaussianWeights[currentBlurCoordinateIndex * 2 + 1];
         GLfloat secondWeight = standardGaussianWeights[currentBlurCoordinateIndex * 2 + 2];
         GLfloat optimizedWeight = firstWeight + secondWeight;
-        int index1 = (unsigned long)((currentBlurCoordinateIndex * 2) + 1);
-        int index2 = (unsigned long)((currentBlurCoordinateIndex * 2) + 2);
+        int index1 = static_cast<int>((currentBlurCoordinateIndex * 2) + 1);
+        int index2 = static_cast<int>((currentBlurCoordinateIndex * 2) + 2);
         ss << "   sum += texture2D(inputImageTexture, blurCoordinates[" << index1 << "]) * " << optimizedWeight << ";\n";
         ss << "   sum += texture2D(inputImageTexture, blurCoordinates[" << index2 << "]) * " << optimizedWeight << ";\n";
     }
@@ -125,15 +125,15 @@ std::string vertexShaderForOptimizedBlur(int blurRadius, float sigma) {
     ss << "attribute vec4 inputTextureCoordinate;\n";
     ss << "uniform float texelWidthOffset;\n";
     ss << "uniform float texelHeightOffset;\n\n";
-    ss << "varying vec2 blurCoordinates[" << (unsigned long)(1 + (numberOfOptimizedOffsets * 2)) << "];\n\n";
+    ss << "varying vec2 blurCoordinates[" << static_cast<int>(1 + (numberOfOptimizedOffsets * 2)) << "];\n\n";
     ss << "void main()\n";
     ss << "{\n";
     ss << "   gl_Position = position;\n";
     ss << "   vec2 singleStepOffset = vec2(texelWidthOffset, texelHeightOffset);\n";
     ss << "   blurCoordinates[0] = inputTextureCoordinate.xy;\n";
     for (int currentOptimizedOffset = 0; currentOptimizedOffset < numberOfOptimizedOffsets; currentOptimizedOffset++) {
-        int x1 = (unsigned long)((currentOptimizedOffset * 2) + 1);
-        int x2 = (unsigned long)((currentOptimizedOffset * 2) + 2);
+        int x1 = static_cast<int>((currentOptimizedOffset * 2) + 1);
+        int x2 = static_cast<int>((currentOptimizedOffset * 2) + 2);
         const auto& optOffset = optimizedGaussianOffsets[currentOptimizedOffset];
 
         ss << "   blurCoordinates[" << x1 << "] = inputTextureCoordinate.xy + singleStepOffset * " << optOffset << ";\n";

--- a/ogles_gpgpu/common/tools.h
+++ b/ogles_gpgpu/common/tools.h
@@ -18,8 +18,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
-
-using namespace std;
+#include <functional>
 
 namespace ogles_gpgpu {
 
@@ -47,13 +46,13 @@ public:
     /**
      * Split a string <s> by delimiter <delim>.
      */
-    static vector<string> split(const string& s, char delim = ' ');
+    static std::vector<std::string> split(const std::string& s, char delim = ' ');
 
     /**
      * Replace all strings <from> in <str> by <to>.
      * Code from http://stackoverflow.com/a/3418285.
      */
-    static void strReplaceAll(string& str, const string& from, const string& to);
+    static void strReplaceAll(std::string& str, const std::string& from, const std::string& to);
 
 #ifdef OGLES_GPGPU_BENCHMARK
     static void resetTimeMeasurement();
@@ -73,5 +72,18 @@ private:
 #endif
 };
 }
+
+// https://stackoverflow.com/a/28413370
+struct scope_guard
+{
+    template <typename Callable>
+    scope_guard(Callable&& f)
+        : m_f(std::forward<Callable>(f))
+    {
+    }
+    scope_guard(scope_guard&&) = default;
+    ~scope_guard() { m_f(); }
+    std::function<void()> m_f;
+};
 
 #endif

--- a/ogles_gpgpu/platform/ios/memtransfer_ios.cpp
+++ b/ogles_gpgpu/platform/ios/memtransfer_ios.cpp
@@ -14,7 +14,7 @@
 #include "../../common/core.h"
 
 /**
- * Most code as from http://allmybrain.com/2011/12/08/rendering-to-a-texture-with-ios-5-texture-cache-api/
+ * Most code is from http://allmybrain.com/2011/12/08/rendering-to-a-texture-with-ios-5-texture-cache-api/
  */
 
 using namespace std;
@@ -97,10 +97,14 @@ void MemTransferIOS::init() {
         0,
         &kCFTypeDictionaryKeyCallBacks,
         &kCFTypeDictionaryValueCallBacks);
+
+    scope_guard destroy = [&]() { CFRelease(empty); };
+    
     bufferAttr = CFDictionaryCreateMutable(kCFAllocatorDefault,
         1,
         &kCFTypeDictionaryKeyCallBacks,
         &kCFTypeDictionaryValueCallBacks);
+
     CFDictionarySetValue(bufferAttr,
         kCVPixelBufferIOSurfacePropertiesKey,
         empty);


### PR DESCRIPTION
* scope_guard `CFRelease(empty)` in iOS texture cache implementation
* `static_cast<int>()` for downcast warnings in shaders
* bump patch to v0.3.6